### PR TITLE
[Bugfix] fixed the invalid logger set-up if the logging is used before we call setup_logger

### DIFF
--- a/federatedscope/core/auxiliaries/utils.py
+++ b/federatedscope/core/auxiliaries/utils.py
@@ -36,18 +36,19 @@ def setup_seed(seed):
 
 def setup_logger(cfg):
     if cfg.verbose > 0:
-        logging.basicConfig(
-            level=logging.INFO,
-            format=
-            "%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s",
-        )
+        logging_level = logging.INFO
     else:
-        logging.basicConfig(
-            level=logging.WARN,
-            format=
-            "%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s",
-        )
+        logging_level = logging.WARN
         logging.warning("Skip DEBUG/INFO messages")
+
+    logging_fmt = "%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s"
+    try:
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging_level)
+        root_handler = root_logger.handlers[0]
+        root_handler.setFormatter(logging.Formatter(logging_fmt))
+    except IndexError:
+        logging.basicConfig(level=logging_level, format=logging_fmt)
 
     # ================ create outdir to save log, exp_config, models, etc,.
 

--- a/federatedscope/core/configs/cfg_fl_setting.py
+++ b/federatedscope/core/configs/cfg_fl_setting.py
@@ -87,7 +87,8 @@ def assert_fl_setting_cfg(cfg):
                 f"Users specify both valid sample_client_rate as {cfg.federate.sample_client_rate} "
                 f"and sample_client_num as {old_sample_client_num}.\n"
                 f"\t\tWe will use the sample_client_rate value to calculate "
-                f"the actual number of participated clients as {cfg.federate.sample_client_num}.")
+                f"the actual number of participated clients as {cfg.federate.sample_client_num}."
+            )
     # (a.2) use sample_client_num, commented since the below two lines do not change anything
     # elif sample_client_num_valid:
     #     cfg.federate.sample_client_num = cfg.federate.sample_client_num

--- a/federatedscope/core/configs/cfg_fl_setting.py
+++ b/federatedscope/core/configs/cfg_fl_setting.py
@@ -79,12 +79,15 @@ def assert_fl_setting_cfg(cfg):
     # (a) sampling case
     if sample_client_rate_valid:
         # (a.1) use sample_client_rate
+        old_sample_client_num = cfg.federate.sample_client_num
         cfg.federate.sample_client_num = max(
             1, int(cfg.federate.sample_client_rate * cfg.federate.client_num))
         if sample_client_num_valid:
             logging.warning(
-                "Users specify both valid sample_client_rate and sample_client_num, "
-                "we will use sample_client_rate")
+                f"Users specify both valid sample_client_rate as {cfg.federate.sample_client_rate} "
+                f"and sample_client_num as {old_sample_client_num}.\n"
+                f"\t\tWe will use the sample_client_rate value to calculate "
+                f"the actual number of participated clients as {cfg.federate.sample_client_num}.")
     # (a.2) use sample_client_num, commented since the below two lines do not change anything
     # elif sample_client_num_valid:
     #     cfg.federate.sample_client_num = cfg.federate.sample_client_num


### PR DESCRIPTION
fixed the invalid logger set-up if the `logging` is used before we call `setup_logger`; resolved the issue #12 