### PR TITLE
Distinguish the concept of `cur_mode` from `cur_data_split`

### DIFF
--- a/federatedscope/core/evaluator.py
+++ b/federatedscope/core/evaluator.py
@@ -38,7 +38,7 @@ class Evaluator(object):
         results = {}
         y_true, y_pred, y_prob = self._check_and_parse(ctx)
         for metric, func in self.eval_metric.items():
-            results["{}_{}".format(ctx.cur_data_split,
+            results["{}_{}".format(ctx.cur_mode,
                                    metric)] = func(ctx=ctx,
                                                    y_true=y_true,
                                                    y_pred=y_pred,
@@ -47,13 +47,13 @@ class Evaluator(object):
         return results
 
     def _check_and_parse(self, ctx):
-        if not '{}_y_true'.format(ctx.cur_data_split) in ctx:
+        if not '{}_y_true'.format(ctx.cur_mode) in ctx:
             raise KeyError('Missing key y_true!')
-        if not '{}_y_prob'.format(ctx.cur_data_split) in ctx:
+        if not '{}_y_prob'.format(ctx.cur_mode) in ctx:
             raise KeyError('Missing key y_prob!')
 
-        y_true = ctx.get("{}_y_true".format(ctx.cur_data_split))
-        y_prob = ctx.get("{}_y_prob".format(ctx.cur_data_split))
+        y_true = ctx.get("{}_y_true".format(ctx.cur_mode))
+        y_prob = ctx.get("{}_y_prob".format(ctx.cur_mode))
 
         if torch is not None and isinstance(y_true, torch.Tensor):
             y_true = y_true.detach().cpu().numpy()
@@ -171,20 +171,20 @@ def eval_rmse(y_true, y_pred, **kwargs):
 
 
 def eval_loss(ctx, **kwargs):
-    return ctx.get('loss_batch_total_{}'.format(ctx.cur_data_split))
+    return ctx.get('loss_batch_total_{}'.format(ctx.cur_mode))
 
 
 def eval_avg_loss(ctx, **kwargs):
-    return ctx.get("loss_batch_total_{}".format(ctx.cur_data_split)) / ctx.get(
-        "num_samples_{}".format(ctx.cur_data_split))
+    return ctx.get("loss_batch_total_{}".format(ctx.cur_mode)) / ctx.get(
+        "num_samples_{}".format(ctx.cur_mode))
 
 
 def eval_total(ctx, **kwargs):
-    return ctx.get("num_samples_{}".format(ctx.cur_data_split))
+    return ctx.get("num_samples_{}".format(ctx.cur_mode))
 
 
 def eval_regular(ctx, **kwargs):
-    return ctx.get("loss_regular_total_{}".format(ctx.cur_data_split))
+    return ctx.get("loss_regular_total_{}".format(ctx.cur_mode))
 
 
 SUPPORT_METRICS = {

--- a/federatedscope/core/evaluator.py
+++ b/federatedscope/core/evaluator.py
@@ -38,12 +38,11 @@ class Evaluator(object):
         results = {}
         y_true, y_pred, y_prob = self._check_and_parse(ctx)
         for metric, func in self.eval_metric.items():
-            results["{}_{}".format(ctx.cur_mode,
-                                   metric)] = func(ctx=ctx,
-                                                   y_true=y_true,
-                                                   y_pred=y_pred,
-                                                   y_prob=y_prob,
-                                                   metric=metric)
+            results["{}_{}".format(ctx.cur_mode, metric)] = func(ctx=ctx,
+                                                                 y_true=y_true,
+                                                                 y_pred=y_pred,
+                                                                 y_prob=y_prob,
+                                                                 metric=metric)
         return results
 
     def _check_and_parse(self, ctx):

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -72,11 +72,11 @@ class GeneralTFTrainer(Trainer):
         ctx.model.to(ctx.device)
 
         # prepare statistics
-        setattr(ctx, "loss_batch_total_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "loss_regular_total_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "num_samples_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "{}_y_true".format(ctx.cur_data_split), [])
-        setattr(ctx, "{}_y_prob".format(ctx.cur_data_split), [])
+        setattr(ctx, "loss_batch_total_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "loss_regular_total_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "num_samples_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "{}_y_true".format(ctx.cur_mode), [])
+        setattr(ctx, "{}_y_prob".format(ctx.cur_mode), [])
 
     def _hook_on_epoch_start(self, ctx):
         # prepare dataloader
@@ -122,24 +122,24 @@ class GeneralTFTrainer(Trainer):
     def _hook_on_batch_end(self, ctx):
         # update statistics
         setattr(
-            ctx, "loss_batch_total_{}".format(ctx.cur_data_split),
-            ctx.get("loss_batch_total_{}".format(ctx.cur_data_split)) +
+            ctx, "loss_batch_total_{}".format(ctx.cur_mode),
+            ctx.get("loss_batch_total_{}".format(ctx.cur_mode)) +
             ctx.loss_batch * ctx.batch_size)
 
         loss_regular = 0.
         setattr(
-            ctx, "loss_regular_total_{}".format(ctx.cur_data_split),
-            ctx.get("loss_regular_total_{}".format(ctx.cur_data_split)) +
+            ctx, "loss_regular_total_{}".format(ctx.cur_mode),
+            ctx.get("loss_regular_total_{}".format(ctx.cur_mode)) +
             loss_regular)
         setattr(
-            ctx, "num_samples_{}".format(ctx.cur_data_split),
-            ctx.get("num_samples_{}".format(ctx.cur_data_split)) +
+            ctx, "num_samples_{}".format(ctx.cur_mode),
+            ctx.get("num_samples_{}".format(ctx.cur_mode)) +
             ctx.batch_size)
 
         # cache label for evaluate
-        ctx.get("{}_y_true".format(ctx.cur_data_split)).append(ctx.y_true)
+        ctx.get("{}_y_true".format(ctx.cur_mode)).append(ctx.y_true)
 
-        ctx.get("{}_y_prob".format(ctx.cur_data_split)).append(ctx.y_prob)
+        ctx.get("{}_y_prob".format(ctx.cur_mode)).append(ctx.y_prob)
 
         # clean temp ctx
         ctx.data_batch = None
@@ -155,11 +155,11 @@ class GeneralTFTrainer(Trainer):
 
         """
         setattr(
-            ctx, "{}_y_true".format(ctx.cur_data_split),
-            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_data_split))))
+            ctx, "{}_y_true".format(ctx.cur_mode),
+            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
         setattr(
-            ctx, "{}_y_prob".format(ctx.cur_data_split),
-            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_data_split))))
+            ctx, "{}_y_prob".format(ctx.cur_mode),
+            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
         results = self.evaluator.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -133,8 +133,7 @@ class GeneralTFTrainer(Trainer):
             loss_regular)
         setattr(
             ctx, "num_samples_{}".format(ctx.cur_mode),
-            ctx.get("num_samples_{}".format(ctx.cur_mode)) +
-            ctx.batch_size)
+            ctx.get("num_samples_{}".format(ctx.cur_mode)) + ctx.batch_size)
 
         # cache label for evaluate
         ctx.get("{}_y_true".format(ctx.cur_mode)).append(ctx.y_true)
@@ -154,12 +153,10 @@ class GeneralTFTrainer(Trainer):
         """Evaluate metrics.
 
         """
-        setattr(
-            ctx, "{}_y_true".format(ctx.cur_mode),
-            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
-        setattr(
-            ctx, "{}_y_prob".format(ctx.cur_mode),
-            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
+        setattr(ctx, "{}_y_true".format(ctx.cur_mode),
+                np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
+        setattr(ctx, "{}_y_prob".format(ctx.cur_mode),
+                np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
         results = self.evaluator.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -480,8 +480,7 @@ class GeneralTorchTrainer(Trainer):
             loss_regular)
         setattr(
             ctx, "num_samples_{}".format(ctx.cur_mode),
-            ctx.get("num_samples_{}".format(ctx.cur_mode)) +
-            ctx.batch_size)
+            ctx.get("num_samples_{}".format(ctx.cur_mode)) + ctx.batch_size)
 
         # cache label for evaluate
         ctx.get("{}_y_true".format(ctx.cur_mode)).append(
@@ -503,12 +502,10 @@ class GeneralTorchTrainer(Trainer):
         """Evaluate metrics.
 
         """
-        setattr(
-            ctx, "{}_y_true".format(ctx.cur_mode),
-            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
-        setattr(
-            ctx, "{}_y_prob".format(ctx.cur_mode),
-            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
+        setattr(ctx, "{}_y_true".format(ctx.cur_mode),
+                np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
+        setattr(ctx, "{}_y_prob".format(ctx.cur_mode),
+                np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
         results = self.evaluator.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -376,12 +376,6 @@ class GeneralTorchTrainer(Trainer):
 
         return self.ctx.eval_metrics
 
-    def validate(self, mode, target_data_split_name="val"):
-        with torch.no_grad():
-            super().evaluate(mode, target_data_split_name)
-
-        return self.ctx.eval_metrics
-
     def register_default_hooks_train(self):
         self.register_hook_in_train(self._hook_on_fit_start_init,
                                     "on_fit_start")

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -415,11 +415,11 @@ class GeneralTorchTrainer(Trainer):
         ctx.model.to(ctx.device)
 
         # prepare statistics
-        setattr(ctx, "loss_batch_total_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "loss_regular_total_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "num_samples_{}".format(ctx.cur_data_split), 0)
-        setattr(ctx, "{}_y_true".format(ctx.cur_data_split), [])
-        setattr(ctx, "{}_y_prob".format(ctx.cur_data_split), [])
+        setattr(ctx, "loss_batch_total_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "loss_regular_total_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "num_samples_{}".format(ctx.cur_mode), 0)
+        setattr(ctx, "{}_y_true".format(ctx.cur_mode), [])
+        setattr(ctx, "{}_y_prob".format(ctx.cur_mode), [])
 
     def _hook_on_epoch_start(self, ctx):
         # prepare dataloader
@@ -472,8 +472,8 @@ class GeneralTorchTrainer(Trainer):
     def _hook_on_batch_end(self, ctx):
         # update statistics
         setattr(
-            ctx, "loss_batch_total_{}".format(ctx.cur_data_split),
-            ctx.get("loss_batch_total_{}".format(ctx.cur_data_split)) +
+            ctx, "loss_batch_total_{}".format(ctx.cur_mode),
+            ctx.get("loss_batch_total_{}".format(ctx.cur_mode)) +
             ctx.loss_batch.item() * ctx.batch_size)
 
         if ctx.get("loss_regular", None) is None or ctx.loss_regular == 0:
@@ -481,19 +481,19 @@ class GeneralTorchTrainer(Trainer):
         else:
             loss_regular = ctx.loss_regular.item()
         setattr(
-            ctx, "loss_regular_total_{}".format(ctx.cur_data_split),
-            ctx.get("loss_regular_total_{}".format(ctx.cur_data_split)) +
+            ctx, "loss_regular_total_{}".format(ctx.cur_mode),
+            ctx.get("loss_regular_total_{}".format(ctx.cur_mode)) +
             loss_regular)
         setattr(
-            ctx, "num_samples_{}".format(ctx.cur_data_split),
-            ctx.get("num_samples_{}".format(ctx.cur_data_split)) +
+            ctx, "num_samples_{}".format(ctx.cur_mode),
+            ctx.get("num_samples_{}".format(ctx.cur_mode)) +
             ctx.batch_size)
 
         # cache label for evaluate
-        ctx.get("{}_y_true".format(ctx.cur_data_split)).append(
+        ctx.get("{}_y_true".format(ctx.cur_mode)).append(
             ctx.y_true.detach().cpu().numpy())
 
-        ctx.get("{}_y_prob".format(ctx.cur_data_split)).append(
+        ctx.get("{}_y_prob".format(ctx.cur_mode)).append(
             ctx.y_prob.detach().cpu().numpy())
 
         # clean temp ctx
@@ -510,11 +510,11 @@ class GeneralTorchTrainer(Trainer):
 
         """
         setattr(
-            ctx, "{}_y_true".format(ctx.cur_data_split),
-            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_data_split))))
+            ctx, "{}_y_true".format(ctx.cur_mode),
+            np.concatenate(ctx.get("{}_y_true".format(ctx.cur_mode))))
         setattr(
-            ctx, "{}_y_prob".format(ctx.cur_data_split),
-            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_data_split))))
+            ctx, "{}_y_prob".format(ctx.cur_mode),
+            np.concatenate(ctx.get("{}_y_prob".format(ctx.cur_mode))))
         results = self.evaluator.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -167,7 +167,7 @@ class Trainer(object):
     def train(self, target_data_split_name="train", hooks_set=None):
         pass
 
-    def evaluate(self, target_data_split_name="test", hooks_set=None):
+    def evaluate(self, mode, target_data_split_name="test", hooks_set=None):
         hooks_set = self.hooks_in_eval if hooks_set is None else hooks_set
         if self.ctx.get(
                 f"{target_data_split_name}_data") is None and self.ctx.get(
@@ -178,7 +178,7 @@ class Trainer(object):
             )
             self.ctx.eval_metrics = {}
         else:
-            self._run_routine("test", hooks_set, target_data_split_name)
+            self._run_routine(mode, hooks_set, target_data_split_name)
 
         return self.ctx.eval_metrics
 
@@ -370,15 +370,15 @@ class GeneralTorchTrainer(Trainer):
         self.ctx.model.load_state_dict(self._param_filter(model_parameters),
                                        strict=False)
 
-    def evaluate(self, target_data_split_name="test"):
+    def evaluate(self, mode, target_data_split_name="test"):
         with torch.no_grad():
-            super().evaluate(target_data_split_name)
+            super().evaluate(mode, target_data_split_name)
 
         return self.ctx.eval_metrics
 
-    def validate(self, target_data_split_name="val"):
+    def validate(self, mode, target_data_split_name="val"):
         with torch.no_grad():
-            super().evaluate(target_data_split_name)
+            super().evaluate(mode, target_data_split_name)
 
         return self.ctx.eval_metrics
 

--- a/federatedscope/core/trainers/trainer_FedEM.py
+++ b/federatedscope/core/trainers/trainer_FedEM.py
@@ -113,7 +113,7 @@ class FedEMTrainer(GeneralMultiModelTrainer):
             # gathers losses for all sample in iterator for each internal model, calling *evaluate()*
             for model_idx in range(self.model_nums):
                 self._switch_model_ctx(model_idx)
-                self.evaluate(target_data_split_name="train")
+                self.evaluate(mode='test', target_data_split_name="train")
 
             self.weights_data_sample = f_softmax(
                 (torch.log(self.weights_internal_models) -

--- a/federatedscope/core/trainers/trainer_FedEM.py
+++ b/federatedscope/core/trainers/trainer_FedEM.py
@@ -128,20 +128,20 @@ class FedEMTrainer(GeneralMultiModelTrainer):
         """
             Ensemble evaluation
         """
-        cur_data = ctx.cur_data_split
-        if f"{cur_data}_y_prob_ensemble" not in ctx:
-            ctx[f"{cur_data}_y_prob_ensemble"] = 0
-        ctx[f"{cur_data}_y_prob_ensemble"] += np.concatenate(ctx[f"{cur_data}_y_prob"]) * \
+        cur_mode = ctx.cur_mode
+        if f"{cur_mode}_y_prob_ensemble" not in ctx:
+            ctx[f"{cur_mode}_y_prob_ensemble"] = 0
+        ctx[f"{cur_mode}_y_prob_ensemble"] += np.concatenate(ctx[f"{cur_mode}_y_prob"]) * \
                                     self.weights_internal_models[ctx.cur_model_idx].item()
 
         # do metrics calculation after the last internal model evaluation done
         if ctx.cur_model_idx == self.model_nums - 1:
-            ctx[f"{cur_data}_y_true"] = np.concatenate(
-                ctx[f"{cur_data}_y_true"])
-            ctx[f"{cur_data}_y_prob"] = ctx[f"{cur_data}_y_prob_ensemble"]
+            ctx[f"{cur_mode}_y_true"] = np.concatenate(
+                ctx[f"{cur_mode}_y_true"])
+            ctx[f"{cur_mode}_y_prob"] = ctx[f"{cur_mode}_y_prob_ensemble"]
             ctx.eval_metrics = self.evaluator.eval(ctx)
-            # reset for next run_routine that may have different len([f"{cur_data}_y_prob"])
-            ctx[f"{cur_data}_y_prob_ensemble"] = 0
+            # reset for next run_routine that may have different len([f"{cur_mode}_y_prob"])
+            ctx[f"{cur_mode}_y_prob_ensemble"] = 0
 
-        ctx[f"{cur_data}_y_prob"] = []
-        ctx[f"{cur_data}_y_true"] = []
+        ctx[f"{cur_mode}_y_prob"] = []
+        ctx[f"{cur_mode}_y_true"] = []

--- a/federatedscope/core/worker/client.py
+++ b/federatedscope/core/worker/client.py
@@ -256,7 +256,7 @@ class Client(Worker):
             self.trainer.update(message.content)
         metrics = {}
         for split in self._cfg.eval.split:
-            eval_metrics = self.trainer.evaluate(mode=split, target_data_split_name=split)
+            eval_metrics = self.trainer.evaluate(mode="test", target_data_split_name=split)
             for key in eval_metrics:
                 logging.info(
                     'Client #{:d}: (Evaluation ({:s} set) at Round #{:d}) {:s} is {:.6f}'

--- a/federatedscope/core/worker/client.py
+++ b/federatedscope/core/worker/client.py
@@ -257,7 +257,8 @@ class Client(Worker):
         metrics = {}
         for split in self._cfg.eval.split:
             mode = split if split != "train" else "test"
-            eval_metrics = self.trainer.evaluate(mode=mode, target_data_split_name=split)
+            eval_metrics = self.trainer.evaluate(mode=mode,
+                                                 target_data_split_name=split)
             for key in eval_metrics:
                 logging.info(
                     'Client #{:d}: (Evaluation ({:s} set) at Round #{:d}) {:s} is {:.6f}'

--- a/federatedscope/core/worker/client.py
+++ b/federatedscope/core/worker/client.py
@@ -256,7 +256,8 @@ class Client(Worker):
             self.trainer.update(message.content)
         metrics = {}
         for split in self._cfg.eval.split:
-            eval_metrics = self.trainer.evaluate(mode="test", target_data_split_name=split)
+            mode = split if split != "train" else "test"
+            eval_metrics = self.trainer.evaluate(mode=mode, target_data_split_name=split)
             for key in eval_metrics:
                 logging.info(
                     'Client #{:d}: (Evaluation ({:s} set) at Round #{:d}) {:s} is {:.6f}'

--- a/federatedscope/core/worker/client.py
+++ b/federatedscope/core/worker/client.py
@@ -256,7 +256,7 @@ class Client(Worker):
             self.trainer.update(message.content)
         metrics = {}
         for split in self._cfg.eval.split:
-            eval_metrics = self.trainer.evaluate(target_data_split_name=split)
+            eval_metrics = self.trainer.evaluate(mode=split, target_data_split_name=split)
             for key in eval_metrics:
                 logging.info(
                     'Client #{:d}: (Evaluation ({:s} set) at Round #{:d}) {:s} is {:.6f}'

--- a/federatedscope/core/worker/server.py
+++ b/federatedscope/core/worker/server.py
@@ -560,7 +560,7 @@ class Server(Worker):
                 # Preform evaluation in server
                 metrics = {}
                 for split in self._cfg.eval.split:
-                    eval_metrics = trainer.evaluate(
+                    eval_metrics = trainer.evaluate(mode=split,
                         target_data_split_name=split)
                     metrics.update(**eval_metrics)
                 formatted_eval_res = formatted_logging(

--- a/federatedscope/core/worker/server.py
+++ b/federatedscope/core/worker/server.py
@@ -561,8 +561,8 @@ class Server(Worker):
                 metrics = {}
                 for split in self._cfg.eval.split:
                     mode = split if split != "train" else "test"
-                    eval_metrics = trainer.evaluate(mode=mode,
-                        target_data_split_name=split)
+                    eval_metrics = trainer.evaluate(
+                        mode=mode, target_data_split_name=split)
                     metrics.update(**eval_metrics)
                 formatted_eval_res = formatted_logging(
                     metrics,

--- a/federatedscope/core/worker/server.py
+++ b/federatedscope/core/worker/server.py
@@ -560,7 +560,7 @@ class Server(Worker):
                 # Preform evaluation in server
                 metrics = {}
                 for split in self._cfg.eval.split:
-                    eval_metrics = trainer.evaluate(mode=split,
+                    eval_metrics = trainer.evaluate(mode="test",
                         target_data_split_name=split)
                     metrics.update(**eval_metrics)
                 formatted_eval_res = formatted_logging(

--- a/federatedscope/core/worker/server.py
+++ b/federatedscope/core/worker/server.py
@@ -560,7 +560,8 @@ class Server(Worker):
                 # Preform evaluation in server
                 metrics = {}
                 for split in self._cfg.eval.split:
-                    eval_metrics = trainer.evaluate(mode="test",
+                    mode = split if split != "train" else "test"
+                    eval_metrics = trainer.evaluate(mode=mode,
                         target_data_split_name=split)
                     metrics.update(**eval_metrics)
                 formatted_eval_res = formatted_logging(


### PR DESCRIPTION
The concepts of `ctx.cur_mode` and `ctx.cur_data_split` in the class `Context` are confused. This PR tries to distinguish them as follows
1. `ctx.cur_mode`
    - distinguish the "train", "test" and "validate" processes; 
    - decide which `hook_set` to run; 
    - modify the mode of the running model, e.g.  `model.train()`;
    - name the variables related to current process, e.g. `loss_batch_total_${ctx.cur_mode}`
    
2. `ctx.cur_data_split`
    - specify the dataset used in the function of `run_routine`
    - used to name the variable related to current dataset, e.g. `num_${ctx.cur_data_split}_epoch`

