### PR TITLE
Update federatedscope-torch1.10.Dockerfile

### DIFF
--- a/enviroment/docker_files/federatedscope-torch1.10.Dockerfile
+++ b/enviroment/docker_files/federatedscope-torch1.10.Dockerfile
@@ -13,6 +13,10 @@ SHELL ["/bin/bash", "-c"]
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+# remove nvidia apt repo cache to avoid GPG error
+RUN rm /etc/apt/sources.list.d/cuda.list
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+
 # install basic tools
 RUN apt-get -y update \
     && apt-get -y install curl git gcc g++ make openssl libssl-dev libbz2-dev libreadline-dev libsqlite3-dev python-dev libmysqlclient-dev


### PR DESCRIPTION
remove nvidia apt repo source to avoid GPG error "public key not available“ under ubuntu 20.04