### PR TITLE
Modify the log for hooks_in_train/test (#178 )

### DIFF
--- a/federatedscope/core/auxiliaries/utils.py
+++ b/federatedscope/core/auxiliaries/utils.py
@@ -380,8 +380,15 @@ def logline_2_wandb_dict(exp_stop_normal, line, log_res_best, raw_out):
 
 
 def format_log_hooks(hooks_set):
-    print_dict = collections.defaultdict(list)
-    for trigger, hooks in hooks_set.items():
-        for hook in hooks:
-            print_dict[trigger].append(hook.__name__)
-    return json.dumps(print_dict, indent=2).replace('\n', '\n\t')
+    def format_dict(target_dict):
+        print_dict = collections.defaultdict(list)
+        for k, v in target_dict.items():
+            for element in v:
+                print_dict.append(element.__name__)
+        return print_dict
+
+    if isinstance(hooks_set, list):
+        print_obj = [format_dict(_) for _ in hooks_set]
+    elif isinstance(hooks_set, dict):
+        print_obj = format_dict(hooks_set)
+    return json.dumps(print_obj, indent=2).replace('\n', '\n\t')

--- a/federatedscope/core/auxiliaries/utils.py
+++ b/federatedscope/core/auxiliaries/utils.py
@@ -384,7 +384,7 @@ def format_log_hooks(hooks_set):
         print_dict = collections.defaultdict(list)
         for k, v in target_dict.items():
             for element in v:
-                print_dict.append(element.__name__)
+                print_dict[k].append(element.__name__)
         return print_dict
 
     if isinstance(hooks_set, list):

--- a/federatedscope/core/auxiliaries/utils.py
+++ b/federatedscope/core/auxiliaries/utils.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import json
 import logging
@@ -376,3 +377,11 @@ def logline_2_wandb_dict(exp_stop_normal, line, log_res_best, raw_out):
                                 log_res_best[
                                     f"{final_type}/{inner_key}"] = inner_val
     return exp_stop_normal, log_res
+
+
+def format_log_hooks(hooks_set):
+    print_dict = collections.defaultdict(list)
+    for trigger, hooks in hooks_set.items():
+        for hook in hooks:
+            print_dict[trigger].append(hook.__name__)
+    return json.dumps(print_dict, indent=2).replace('\n', '\n\t')

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -4,7 +4,8 @@ import logging
 import os
 import numpy as np
 
-from federatedscope.core.auxiliaries import utils
+from federatedscope.core.auxiliaries.utils import format_log_hooks
+from federatedscope.core.auxiliaries.utils import filter_by_specified_keywords
 from federatedscope.core.trainers.context import Context
 from federatedscope.core.monitors.metric_calculator import MetricCalculator
 
@@ -300,8 +301,8 @@ class Trainer(object):
             f"Filtered para names in local update: {filtered_para_names}.")
 
         logger.info(f"After register default hooks,\n"
-                    f"\tthe hooks_in_train is: {self.hooks_in_train};\n"
-                    f"\tthe hooks_in_eval is {self.hooks_in_eval}")
+                    f"\tthe hooks_in_train is:\n\t{format_log_hooks(self.hooks_in_train)};\n"
+                    f"\tthe hooks_in_eval is:\n\t{format_log_hooks(self.hooks_in_eval)}")
 
     def finetune(self):
         pass
@@ -325,7 +326,7 @@ class Trainer(object):
 
         trainable_filter = lambda p: True if self.cfg.personalization.share_non_trainable_para else \
             lambda p: p in self.ctx.trainable_para_names
-        keyword_filter = utils.filter_by_specified_keywords
+        keyword_filter = filter_by_specified_keywords
         return dict(
             filter(
                 lambda elem: trainable_filter(elem[1]) and keyword_filter(

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -128,7 +128,7 @@ class Trainer(object):
                         hook_idx].__name__:
                     del_one = hooks_dict[target_trigger].pop(hook_idx)
                     logger.info(
-                        f"Remove the hook `{del_one}` from hooks_set at trigger `{target_trigger}`"
+                        f"Remove the hook `{del_one.__name__}` from hooks_set at trigger `{target_trigger}`"
                     )
                     del_one_hook_idx = hook_idx
                     break


### PR DESCRIPTION
To solve #178 , the current log of `hooks_in_train` and `hooks_in_eval` is as follows
```
2022-06-22 02:57:53,122 (trainer:303) INFO: After register default hooks,
	the hooks_in_train is:
	{
	  "on_fit_start": [
	    "_hook_on_fit_start_init",
	    "_hook_on_fit_start_calculate_model_size"
	  ],
	  "on_epoch_start": [
	    "_hook_on_epoch_start"
	  ],
	  "on_batch_start": [
	    "_hook_on_batch_start_init"
	  ],
	  "on_batch_forward": [
	    "_hook_on_batch_forward",
	    "_hook_on_batch_forward_regularizer",
	    "_hook_on_batch_forward_flop_count"
	  ],
	  "on_batch_backward": [
	    "_hook_on_batch_backward"
	  ],
	  "on_batch_end": [
	    "_hook_on_batch_end"
	  ],
	  "on_fit_end": [
	    "_hook_on_fit_end"
	  ]
	};
	the hooks_in_eval is:
	{
	  "on_fit_start": [
	    "_hook_on_fit_start_init"
	  ],
	  "on_epoch_start": [
	    "_hook_on_epoch_start"
	  ],
	  "on_batch_start": [
	    "_hook_on_batch_start_init"
	  ],
	  "on_batch_forward": [
	    "_hook_on_batch_forward"
	  ],
	  "on_batch_end": [
	    "_hook_on_batch_end"
	  ],
	  "on_fit_end": [
	    "_hook_on_fit_end"
	  ]
	}
```