### PR TITLE
[Feature] Add Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,7 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+      - 'hotfix'
   - title: '🧰 Maintenance'
     label: 'chore'
 exclude-labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'Feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,8 @@ categories:
       - 'bug'
   - title: '🧰 Maintenance'
     label: 'chore'
+exclude-labels:
+  - 'skip-changelog'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -30,3 +32,4 @@ template: |
   ## Changes
 
   $CHANGES
+


### PR DESCRIPTION
We use [release-drafter](https://github.com/release-drafter/release-drafter) to generate the release note automatically.
The configuration file can be found in ~/.github/release-drafter.yml.
And the PR will be grouped into three types according to labels in our release note:
* Features 
  * feature
  * enhancement
  * Feature
* Bug Fixes 
  * fix
  * bugfix
  * bug
  * hotfix
* Maintenance 
  * chore

Label [skip-changelog](https://github.com/alibaba/FederatedScope/labels/skip-changelog) would make PR not shown in the release draft.

So, please carefully set the **label** for each PR, thanks.