### PR TITLE
Enable to use share_local_model in non-online aggregation

### DIFF
--- a/federatedscope/autotune/fedex/client.py
+++ b/federatedscope/autotune/fedex/client.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import copy
 
 from federatedscope.core.message import Message
 from federatedscope.core.worker import Client
@@ -48,6 +49,9 @@ class FedExClient(Client):
         # self.model.load_state_dict(content)
         self.state = round
         sample_size, model_para_all, results = self.trainer.train()
+        if self._cfg.federate.share_local_model and not \
+                self._cfg.federate.online_aggr:
+            model_para_all = copy.deepcopy(model_para_all)
         logger.info(
             self._monitor.format_eval_res(results,
                                           rnd=self.state,

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -163,8 +163,8 @@ class GeneralTFTrainer(Trainer):
         results = self.metric_calculator.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 
-    def update(self, model_parameters):
-        self.ctx.model.load_state_dict(model_parameters)
+    def update(self, model_parameters, strict=False):
+        self.ctx.model.load_state_dict(model_parameters, strict=strict)
 
     def save_model(self, path, cur_round=-1):
         pass

--- a/federatedscope/core/trainers/torch_trainer.py
+++ b/federatedscope/core/trainers/torch_trainer.py
@@ -58,7 +58,7 @@ class GeneralTorchTrainer(Trainer):
             raise TypeError("Type of data should be dict.")
         return init_dict
 
-    def update(self, model_parameters):
+    def update(self, model_parameters, strict=False):
         '''
             Called by the FL client to update the model parameters
         Arguments:
@@ -69,7 +69,7 @@ class GeneralTorchTrainer(Trainer):
                 model_parameters[key] = torch.FloatTensor(
                     model_parameters[key])
         self.ctx.model.load_state_dict(self._param_filter(model_parameters),
-                                       strict=False)
+                                       strict=strict)
 
     def evaluate(self, target_data_split_name="test"):
         with torch.no_grad():

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -300,11 +300,12 @@ class Trainer(object):
             else:
                 self.ctx.model.to(torch.device("cpu"))
 
-    def update(self, model_parameters):
+    def update(self, model_parameters, strict=False):
         '''
             Called by the FL client to update the model parameters
         Arguments:
             model_parameters (dict): {model_name: model_val}
+            strict (bool): ensure the k-v paris are strictly same
         '''
         pass
 

--- a/federatedscope/core/trainers/trainer_multi_model.py
+++ b/federatedscope/core/trainers/trainer_multi_model.py
@@ -275,7 +275,7 @@ class GeneralMultiModelTrainer(GeneralTorchTrainer):
         return trained_model_para[
             0] if self.model_nums == 1 else trained_model_para
 
-    def update(self, model_parameters):
+    def update(self, model_parameters, strict=False):
         # update multiple model paras
         """
         Arguments:
@@ -283,7 +283,7 @@ class GeneralMultiModelTrainer(GeneralTorchTrainer):
             state_dict.
         """
         if self.model_nums == 1:
-            super().update(model_parameters)
+            super().update(model_parameters, strict=strict)
         else:
             assert isinstance(model_parameters, list) and isinstance(
                 model_parameters[0], dict), \
@@ -296,7 +296,7 @@ class GeneralMultiModelTrainer(GeneralTorchTrainer):
             for model_idx in range(self.model_nums):
                 self.ctx.models[model_idx].load_state_dict(self._param_filter(
                     model_parameters[model_idx]),
-                                                           strict=False)
+                                                           strict=strict)
 
     def train(self, target_data_split_name="train"):
         # return multiple model paras

--- a/federatedscope/core/worker/client.py
+++ b/federatedscope/core/worker/client.py
@@ -210,7 +210,8 @@ class Client(Worker):
         else:
             round, sender, content = message.state, message.sender, \
                                      message.content
-            self.trainer.update(content)
+            self.trainer.update(content,
+                                strict=self._cfg.federate.share_local_model)
             self.state = round
             if self.early_stopper.early_stopped and \
                     self._cfg.federate.method in ["local", "global"]:
@@ -348,7 +349,8 @@ class Client(Worker):
         sender = message.sender
         self.state = message.state
         if message.content is not None:
-            self.trainer.update(message.content)
+            self.trainer.update(message.content,
+                                strict=self._cfg.federate.share_local_model)
         if self.early_stopper.early_stopped and self._cfg.federate.method in [
                 "local", "global"
         ]:
@@ -408,7 +410,8 @@ class Client(Worker):
             f"=================")
 
         if message.content is not None:
-            self.trainer.update(message.content)
+            self.trainer.update(message.content,
+                                strict=self._cfg.federate.share_local_model)
 
         self._monitor.finish_fl()
 

--- a/federatedscope/gfl/fedsageplus/worker.py
+++ b/federatedscope/gfl/fedsageplus/worker.py
@@ -1,5 +1,6 @@
 import torch
 import logging
+import copy
 
 from torch_geometric.loader import NeighborSampler
 
@@ -384,6 +385,9 @@ class FedSagePlusClient(Client):
         self.trainer_clf.update(content)
         self.state = round
         sample_size, clf_para, results = self.trainer_clf.train()
+        if self._cfg.federate.share_local_model and not \
+                self._cfg.federate.online_aggr:
+            clf_para = copy.deepcopy(clf_para)
         logger.info(
             self._monitor.format_eval_res(results,
                                           rnd=self.state,

--- a/federatedscope/gfl/gcflplus/worker.py
+++ b/federatedscope/gfl/gcflplus/worker.py
@@ -185,6 +185,9 @@ class GCFLPlusClient(Client):
         self.trainer.update(content)
         self.state = round
         sample_size, model_para, results = self.trainer.train()
+        if self._cfg.federate.share_local_model and not \
+                self._cfg.federate.online_aggr:
+            model_para = copy.deepcopy(model_para)
         logger.info(
             self._monitor.format_eval_res(results,
                                           rnd=self.state,


### PR DESCRIPTION
As the title says. This feature is designed for efficient simulation and cannot support personalized algorithms where clients don't share the complete model in this version.