### PR TITLE
[bug_fix] fix call_link_level_trainer() and call_node_level_trainer()

### DIFF
--- a/federatedscope/gfl/trainer/linktrainer.py
+++ b/federatedscope/gfl/trainer/linktrainer.py
@@ -206,7 +206,7 @@ def call_link_level_trainer(trainer_type):
     elif trainer_type == 'linkminibatch_trainer':
         trainer_builder = LinkMiniBatchTrainer
     else:
-        raise ValueError
+        trainer_builder = None
 
     return trainer_builder
 

--- a/federatedscope/gfl/trainer/nodetrainer.py
+++ b/federatedscope/gfl/trainer/nodetrainer.py
@@ -180,7 +180,7 @@ def call_node_level_trainer(trainer_type):
     elif trainer_type == 'nodeminibatch_trainer':
         trainer_builder = NodeMiniBatchTrainer
     else:
-        raise ValueError
+        trainer_builder = None
 
     return trainer_builder
 


### PR DESCRIPTION
This PR fixes `call_link_level_trainer()` and `call_node_level_trainer()` raising `ValueError` when `trainer_type` doesn't match. When a custom trainer is registered, the above functions should return `None` instead of raising the error, so that `trainer_builder` can properly get the custom trainer.