### PR TITLE
[Feature] Add parameters to control whether to check cfg

### DIFF
--- a/federatedscope/autotune/fedex/client.py
+++ b/federatedscope/autotune/fedex/client.py
@@ -25,8 +25,8 @@ class FedExClient(Client):
             cmd_args.append(v)
 
         self._cfg.defrost()
-        self._cfg.merge_from_list(cmd_args)
-        self._cfg.freeze(inform=False)
+        self._cfg.merge_from_list(cmd_args, check_cfg=False)
+        self._cfg.freeze(inform=False, check_cfg=False)
 
         self.trainer.ctx.setup_vars()
 

--- a/federatedscope/core/configs/config.py
+++ b/federatedscope/core/configs/config.py
@@ -74,7 +74,7 @@ class CN(CfgNode):
     def register_cfg_check_fun(self, cfg_check_fun):
         self.__cfg_check_funcs__.append(cfg_check_fun)
 
-    def merge_from_file(self, cfg_filename):
+    def merge_from_file(self, cfg_filename, check_cfg=True):
         """
             load configs from a yaml file, another cfg instance or a list
             stores the keys and values.
@@ -88,10 +88,10 @@ class CN(CfgNode):
         self.merge_from_other_cfg(cfg)
         self.__cfg_check_funcs__.clear()
         self.__cfg_check_funcs__.extend(cfg_check_funcs)
-        self.assert_cfg()
+        self.assert_cfg(check_cfg)
         set_help_info(self, self.__help_info__)
 
-    def merge_from_other_cfg(self, cfg_other):
+    def merge_from_other_cfg(self, cfg_other, check_cfg=True):
         """
             load configs from another cfg instance
 
@@ -103,10 +103,10 @@ class CN(CfgNode):
         _merge_a_into_b(cfg_other, self, self, [])
         self.__cfg_check_funcs__.clear()
         self.__cfg_check_funcs__.extend(cfg_check_funcs)
-        self.assert_cfg()
+        self.assert_cfg(check_cfg)
         set_help_info(self, self.__help_info__)
 
-    def merge_from_list(self, cfg_list):
+    def merge_from_list(self, cfg_list, check_cfg=True):
         """
            load configs from a list stores the keys and values.
            modified `merge_from_list` in `yacs.config.py` to allow adding
@@ -119,17 +119,18 @@ class CN(CfgNode):
         super().merge_from_list(cfg_list)
         self.__cfg_check_funcs__.clear()
         self.__cfg_check_funcs__.extend(cfg_check_funcs)
-        self.assert_cfg()
+        self.assert_cfg(check_cfg)
         set_help_info(self, self.__help_info__)
 
-    def assert_cfg(self):
+    def assert_cfg(self, check_cfg=True):
         """
             check the validness of the configuration instance
 
         :return:
         """
-        for check_func in self.__cfg_check_funcs__:
-            check_func(self)
+        if check_cfg:
+            for check_func in self.__cfg_check_funcs__:
+                check_func(self)
 
     def clean_unused_sub_cfgs(self):
         """
@@ -170,14 +171,14 @@ class CN(CfgNode):
             if isinstance(v, Argument):
                 self[k] = v.value
 
-    def ready_for_run(self):
-        self.assert_cfg()
+    def ready_for_run(self, check_cfg=True):
+        self.assert_cfg(check_cfg)
         self.clean_unused_sub_cfgs()
         self.check_required_args()
         self.de_arguments()
         self.is_ready_for_run = True
 
-    def freeze(self, inform=True, save=True):
+    def freeze(self, inform=True, save=True, check_cfg=True):
         """
             1) make the cfg attributes immutable;
             2) if save=True, save the frozen cfg_check_funcs into
@@ -186,7 +187,7 @@ class CN(CfgNode):
 
         :return:
         """
-        self.ready_for_run()
+        self.ready_for_run(check_cfg)
         super(CN, self).freeze()
 
         if save:  # save the final cfg


### PR DESCRIPTION
1. Add parameters to control whether to check `cfg`.
2. Set `check_cfg` to False in FedEx to avoid Redundant logs.