### PR TITLE
fix update key not enabled & remove redundant cfg key

### DIFF
--- a/federatedscope/contrib/metrics/example.py
+++ b/federatedscope/contrib/metrics/example.py
@@ -9,8 +9,9 @@ def MyMetric(ctx, **kwargs):
 
 def call_my_metric(types):
     if METRIC_NAME in types:
+        the_larger_the_better = True
         metric_builder = MyMetric
-        return METRIC_NAME, metric_builder
+        return METRIC_NAME, metric_builder, the_larger_the_better
 
 
 register_metric(METRIC_NAME, call_my_metric)

--- a/federatedscope/contrib/metrics/poison_acc.py
+++ b/federatedscope/contrib/metrics/poison_acc.py
@@ -25,7 +25,8 @@ def load_poison_metrics(ctx, y_true, y_pred, y_prob, **kwargs):
 
 def call_poison_metric(types):
     if 'poison_attack_acc' in types:
-        return 'poison_attack_acc', load_poison_metrics
+        the_larger_the_better = True
+        return 'poison_attack_acc', load_poison_metrics, the_larger_the_better
 
 
 register_metric('poison_attack_acc', call_poison_metric)

--- a/federatedscope/core/auxiliaries/metric_builder.py
+++ b/federatedscope/core/auxiliaries/metric_builder.py
@@ -16,6 +16,6 @@ def get_metric(types):
     for func in register.metric_dict.values():
         res = func(types)
         if res is not None:
-            name, metric = res
-            metrics[name] = metric
+            name, metric, the_larger_the_better = res
+            metrics[name] = metric, the_larger_the_better
     return metrics

--- a/federatedscope/core/configs/README.md
+++ b/federatedscope/core/configs/README.md
@@ -180,7 +180,6 @@ The following configurations are related to the grad clipping.
 |          `early_stop.patience`           | (int) 5 |  How long to wait after last time the monitored metric improved. |                        Note that the actual_checking_round = `early_step.patience` * `eval.freq`. To disable the early stop, set the `early_stop.patience` <=0                        |
 |            `early_stop.delta`            | (float) 0. |  Minimum change in the monitored metric to indicate a improvement. |                                                                                           -                                                                                           |
 |   `early_stop.improve_indicaator_mode`   | (string) 'best' | Early stop when there is no improvement within the last `early_step.patience` rounds, in ['mean', 'best'] |                                                                             Chosen from 'mean' or 'best'                                                                              |
-|   `early_step.the_smaller_the_better`    | (bool) True | The optimized direction of the chosen metric |                                                                                           -                                                                                           |
 
 
 ### FL Setting

--- a/federatedscope/core/configs/cfg_training.py
+++ b/federatedscope/core/configs/cfg_training.py
@@ -64,7 +64,6 @@ def extend_training_cfg(cfg):
     cfg.early_stop.delta = 0.0
     # Early stop when no improve to last `patience` round, in ['mean', 'best']
     cfg.early_stop.improve_indicator_mode = 'best'
-    cfg.early_stop.the_smaller_the_better = True
 
     # --------------- register corresponding check function ----------
     cfg.register_cfg_check_fun(assert_training_cfg)

--- a/federatedscope/core/monitors/early_stopper.py
+++ b/federatedscope/core/monitors/early_stopper.py
@@ -13,7 +13,7 @@ class EarlyStopper(object):
                  patience=5,
                  delta=0,
                  improve_indicator_mode='best',
-                 the_smaller_the_better=True):
+                 the_larger_the_better=True):
         """
         Args:
             patience (int): How long to wait after last time the monitored
@@ -39,7 +39,7 @@ class EarlyStopper(object):
         self.counter_no_improve = 0
         self.best_metric = None
         self.early_stopped = False
-        self.the_smaller_the_better = the_smaller_the_better
+        self.the_larger_the_better = the_larger_the_better
         self.delta = delta
         self.improve_indicator_mode = improve_indicator_mode
         # For expansion usages of comparisons
@@ -54,12 +54,12 @@ class EarlyStopper(object):
         new_result = history_result[-1]
         if self.best_metric is None:
             self.best_metric = new_result
-        elif self.the_smaller_the_better and self.comparator(
+        elif not self.the_larger_the_better and self.comparator(
                 self.improvement_operator(self.best_metric, -self.delta),
                 new_result):
             # add(best_metric, -delta) < new_result
             self.counter_no_improve += 1
-        elif not self.the_smaller_the_better and self.comparator(
+        elif self.the_larger_the_better and self.comparator(
                 new_result,
                 self.improvement_operator(self.best_metric, self.delta)):
             # new_result < add(best_metric, delta)
@@ -74,12 +74,12 @@ class EarlyStopper(object):
     def __track_and_check_mean(self, history_result):
         new_result = history_result[-1]
         if len(history_result) > self.patience:
-            if self.the_smaller_the_better and self.comparator(
+            if not self.the_larger_the_better and self.comparator(
                     self.improvement_operator(
                         np.mean(history_result[-self.patience - 1:-1]),
                         -self.delta), new_result):
                 self.early_stopped = True
-            elif not self.the_smaller_the_better and self.comparator(
+            elif self.the_larger_the_better and self.comparator(
                     new_result,
                     self.improvement_operator(
                         np.mean(history_result[-self.patience - 1:-1]),

--- a/federatedscope/core/monitors/metric_calculator.py
+++ b/federatedscope/core/monitors/metric_calculator.py
@@ -16,7 +16,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-# TODO: make this as a sub-module of monitor class
 class MetricCalculator(object):
     def __init__(self, eval_metric: Union[Set[str], List[str], str]):
 
@@ -241,6 +240,6 @@ SUPPORT_METRICS = {
     'mse': (eval_mse, False),
     'loss_regular': (eval_regular, False),
     'imp_ratio': (eval_imp_ratio, True),
-    'std': (None, False)**dict.fromkeys([f'hits@{n}' for n in range(1, 101)],
-                                        (eval_hits, True))
+    'std': (None, False),
+    **dict.fromkeys([f'hits@{n}' for n in range(1, 101)], (eval_hits, True))
 }

--- a/federatedscope/core/monitors/metric_calculator.py
+++ b/federatedscope/core/monitors/metric_calculator.py
@@ -41,7 +41,7 @@ class MetricCalculator(object):
     def eval(self, ctx):
         results = {}
         y_true, y_pred, y_prob = self._check_and_parse(ctx)
-        for metric, func in self.eval_metric.items():
+        for metric, (func, _) in self.eval_metric.items():
             results["{}_{}".format(ctx.cur_split,
                                    metric)] = func(ctx=ctx,
                                                    y_true=y_true,
@@ -226,18 +226,21 @@ def eval_imp_ratio(ctx, y_true, y_prob, y_pred, **kwargs):
     return (base - perform) / base * 100.
 
 
+# SUPPORT_METRICS dict, key: `metric_name`, value: (eval_func,
+# the_larger_the_better)
 SUPPORT_METRICS = {
-    'loss': eval_loss,
-    'avg_loss': eval_avg_loss,
-    'total': eval_total,
-    'correct': eval_correct,
-    'acc': eval_acc,
-    'ap': eval_ap,
-    'f1': eval_f1_score,
-    'roc_auc': eval_roc_auc,
-    'rmse': eval_rmse,
-    'mse': eval_mse,
-    'loss_regular': eval_regular,
-    'imp_ratio': eval_imp_ratio,
-    **dict.fromkeys([f'hits@{n}' for n in range(1, 101)], eval_hits)
+    'loss': (eval_loss, False),
+    'avg_loss': (eval_avg_loss, False),
+    'total': (eval_total, False),
+    'correct': (eval_correct, True),
+    'acc': (eval_acc, True),
+    'ap': (eval_ap, True),
+    'f1': (eval_f1_score, True),
+    'roc_auc': (eval_roc_auc, True),
+    'rmse': (eval_rmse, False),
+    'mse': (eval_mse, False),
+    'loss_regular': (eval_regular, False),
+    'imp_ratio': (eval_imp_ratio, True),
+    'std': (None, False)**dict.fromkeys([f'hits@{n}' for n in range(1, 101)],
+                                        (eval_hits, True))
 }

--- a/federatedscope/core/monitors/monitor.py
+++ b/federatedscope/core/monitors/monitor.py
@@ -43,6 +43,16 @@ class Monitor(object):
         self.monitored_object = monitored_object
         self.metric_calculator = MetricCalculator(cfg.eval.metrics)
 
+        # Obtain the whether the larger the better
+        self.round_wise_update_key = cfg.eval.best_res_update_round_wise_key
+        for mode in ['train', 'val', 'test']:
+            if mode in self.round_wise_update_key:
+                update_key = self.round_wise_update_key.split(f'{mode}_')[1]
+        assert update_key in self.metric_calculator.eval_metric, \
+            f'{update_key} not found in metrics.'
+        self.the_larger_the_better = self.metric_calculator.eval_metric[
+            update_key][1]
+
         # =======  efficiency indicators of the worker to be monitored =======
         # leveraged the flops counter provided by [fvcore](
         # https://github.com/facebookresearch/fvcore)
@@ -492,23 +502,12 @@ class Monitor(object):
     def track_download_bytes(self, bytes):
         self.total_download_bytes += bytes
 
-    def update_best_result(self,
-                           best_results,
-                           new_results,
-                           results_type,
-                           round_wise_update_key="val_loss"):
+    def update_best_result(self, best_results, new_results, results_type):
         """
             update best evaluation results.
             by default, the update is based on validation loss with
             `round_wise_update_key="val_loss" `
         """
-        for mode in ['train', 'val', 'test']:
-            if mode in round_wise_update_key:
-                update_key = round_wise_update_key.split(f'{mode}_')[1]
-        assert update_key in self.metric_calculator.eval_metric, \
-            f'{update_key} not found in metrics.'
-        the_larger_the_better = self.metric_calculator.eval_metric[update_key][
-            1]
         update_best_this_round = False
         if not isinstance(new_results, dict):
             raise ValueError(
@@ -520,7 +519,7 @@ class Monitor(object):
             best_result = best_results[results_type]
             # update different keys separately: the best values can be in
             # different rounds
-            if round_wise_update_key is None:
+            if self.round_wise_update_key is None:
                 for key in new_results:
                     cur_result = new_results[key]
                     if 'loss' in key or 'std' in key:  # the smaller,
@@ -554,7 +553,7 @@ class Monitor(object):
                 found_round_wise_update_key = False
                 sorted_keys = []
                 for key in new_results:
-                    if round_wise_update_key in key:
+                    if self.round_wise_update_key in key:
                         sorted_keys.insert(0, key)
                         found_round_wise_update_key = True
                     else:
@@ -565,12 +564,13 @@ class Monitor(object):
                         "is not in target results, "
                         "use another key or check the name. \n"
                         f"Got eval.best_res_update_round_wise_key"
-                        f"={round_wise_update_key}, "
+                        f"={self.round_wise_update_key}, "
                         f"the keys of results are {list(new_results.keys())}")
 
                 for key in sorted_keys:
                     cur_result = new_results[key]
-                    if update_best_this_round or (not the_larger_the_better):
+                    if update_best_this_round or (
+                            not self.the_larger_the_better):
                         # The smaller the better
                         if results_type in [
                                 "client_best_individual",
@@ -582,7 +582,7 @@ class Monitor(object):
                                 best_result[key]:
                             best_result[key] = cur_result
                             update_best_this_round = True
-                    elif update_best_this_round or the_larger_the_better:
+                    elif update_best_this_round or self.the_larger_the_better:
                         # The larger the better
                         if results_type in [
                                 "client_best_individual",

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -136,7 +136,7 @@ class GeneralTFTrainer(Trainer):
         """
         ctx.ys_true = CtxVar(np.concatenate(ctx.ys_true), LIFECYCLE.ROUTINE)
         ctx.ys_prob = CtxVar(np.concatenate(ctx.ys_prob), LIFECYCLE.ROUTINE)
-        results = self.metric_calculator.eval(ctx)
+        results = self.ctx.monitor.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 
     def update(self, model_parameters, strict=False):

--- a/federatedscope/core/trainers/torch_trainer.py
+++ b/federatedscope/core/trainers/torch_trainer.py
@@ -285,7 +285,7 @@ class GeneralTorchTrainer(Trainer):
         """
         ctx.ys_true = CtxVar(np.concatenate(ctx.ys_true), LIFECYCLE.ROUTINE)
         ctx.ys_prob = CtxVar(np.concatenate(ctx.ys_prob), LIFECYCLE.ROUTINE)
-        results = self.metric_calculator.eval(ctx)
+        results = self.ctx.monitor.eval(ctx)
         setattr(ctx, 'eval_metrics', results)
 
     def save_model(self, path, cur_round=-1):

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -10,7 +10,6 @@ from federatedscope.core.auxiliaries.utils import filter_by_specified_keywords
 from federatedscope.core.trainers.context import Context
 from federatedscope.core.trainers.context import CtxVar
 from federatedscope.core.trainers.context import lifecycle
-from federatedscope.core.monitors.metric_calculator import MetricCalculator
 
 try:
     import torch
@@ -41,7 +40,6 @@ class Trainer(object):
                  only_for_eval=False,
                  monitor=None):
         self.cfg = config
-        self.metric_calculator = MetricCalculator(config.eval.metrics)
 
         self.ctx = Context(model,
                            self.cfg,
@@ -49,9 +47,8 @@ class Trainer(object):
                            device,
                            init_dict=self.parse_data(data))
 
-        if monitor is None:
-            logger.warning(
-                f"Will not use monitor in trainer with class {type(self)}")
+        assert monitor is not None, \
+            f"Will not use monitor in trainer with class {type(self)}"
         self.ctx.monitor = monitor
         # the "model_nums", and "models" are used for multi-model case and
         # model size calculation

--- a/federatedscope/core/trainers/trainer.py
+++ b/federatedscope/core/trainers/trainer.py
@@ -48,7 +48,7 @@ class Trainer(object):
                            init_dict=self.parse_data(data))
 
         assert monitor is not None, \
-            f"Will not use monitor in trainer with class {type(self)}"
+            f"Monitor not found in trainer with class {type(self)}"
         self.ctx.monitor = monitor
         # the "model_nums", and "models" are used for multi-model case and
         # model size calculation

--- a/federatedscope/core/trainers/trainer_FedEM.py
+++ b/federatedscope/core/trainers/trainer_FedEM.py
@@ -166,4 +166,4 @@ class FedEMTrainer(GeneralMultiModelTrainer):
             ctx.ys_true = CtxVar(np.concatenate(ctx.ys_true),
                                  LIFECYCLE.ROUTINE)
             ctx.ys_prob = ctx.ys_prob_ensemble
-            ctx.eval_metrics = self.metric_calculator.eval(ctx)
+            ctx.eval_metrics = self.ctx.monitor.eval(ctx)

--- a/federatedscope/core/workers/client.py
+++ b/federatedscope/core/workers/client.py
@@ -83,7 +83,7 @@ class Client(Worker):
         self.early_stopper = EarlyStopper(
             patience, self._cfg.early_stop.delta,
             self._cfg.early_stop.improve_indicator_mode,
-            self._cfg.early_stop.the_smaller_the_better)
+            self._monitor.the_larger_the_better)
 
         # Secret Sharing Manager and message buffer
         self.ss_manager = AdditiveSecretSharing(
@@ -487,12 +487,9 @@ class Client(Worker):
                 role='Client #{}'.format(self.ID),
                 forms='raw',
                 return_raw=True)
-            self._monitor.update_best_result(
-                self.best_results,
-                formatted_eval_res['Results_raw'],
-                results_type=f"client #{self.ID}",
-                round_wise_update_key=self._cfg.eval.
-                best_res_update_round_wise_key)
+            self._monitor.update_best_result(self.best_results,
+                                             formatted_eval_res['Results_raw'],
+                                             results_type=f"client #{self.ID}")
             self.history_results = merge_dict(
                 self.history_results, formatted_eval_res['Results_raw'])
             self.early_stopper.track_and_check(self.history_results[

--- a/federatedscope/core/workers/server.py
+++ b/federatedscope/core/workers/server.py
@@ -60,7 +60,7 @@ class Server(Worker):
         self.early_stopper = EarlyStopper(
             self._cfg.early_stop.patience, self._cfg.early_stop.delta,
             self._cfg.early_stop.improve_indicator_mode,
-            self._cfg.early_stop.the_smaller_the_better)
+            self._monitor.the_larger_the_better)
 
         if self._cfg.federate.share_local_model:
             # put the model to the specified device
@@ -590,9 +590,7 @@ class Server(Worker):
                     self.best_results,
                     metrics_all_clients,
                     results_type="unseen_client_best_individual"
-                    if merge_type == "unseen" else "client_best_individual",
-                    round_wise_update_key=self._cfg.eval.
-                    best_res_update_round_wise_key)
+                    if merge_type == "unseen" else "client_best_individual")
                 self._monitor.save_formatted_results(formatted_logs)
                 for form in self._cfg.eval.report:
                     if form != "raw":
@@ -603,9 +601,7 @@ class Server(Worker):
                             formatted_logs[f"Results_{metric_name}"],
                             results_type=f"unseen_client_summarized_{form}"
                             if merge_type == "unseen" else
-                            f"client_summarized_{form}",
-                            round_wise_update_key=self._cfg.eval.
-                            best_res_update_round_wise_key)
+                            f"client_summarized_{form}")
 
         return formatted_logs_all_set
 
@@ -852,9 +848,7 @@ class Server(Worker):
                 self._monitor.update_best_result(
                     self.best_results,
                     formatted_eval_res['Results_raw'],
-                    results_type="server_global_eval",
-                    round_wise_update_key=self._cfg.eval.
-                    best_res_update_round_wise_key)
+                    results_type="server_global_eval")
                 self.history_results = merge_dict(self.history_results,
                                                   formatted_eval_res)
                 self._monitor.save_formatted_results(formatted_eval_res)

--- a/federatedscope/gfl/baseline/fedavg_gin_minibatch_on_cikmcup.yaml
+++ b/federatedscope/gfl/baseline/fedavg_gin_minibatch_on_cikmcup.yaml
@@ -3,7 +3,6 @@ device: 0
 early_stop:
   patience: 20
   improve_indicator_mode: mean
-  the_smaller_the_better: False
 federate:
   mode: 'standalone'
   make_global_eval: False

--- a/federatedscope/gfl/baseline/isolated_gin_minibatch_on_cikmcup.yaml
+++ b/federatedscope/gfl/baseline/isolated_gin_minibatch_on_cikmcup.yaml
@@ -3,7 +3,6 @@ device: 0
 early_stop:
   patience: 20
   improve_indicator_mode: mean
-  the_smaller_the_better: False
 federate:
   mode: standalone
   method: local

--- a/federatedscope/vertical_fl/worker/vertical_server.py
+++ b/federatedscope/vertical_fl/worker/vertical_server.py
@@ -84,12 +84,9 @@ class vFLServer(Server):
         if self.state % self._cfg.eval.freq == 0 and self.state != \
                 self.total_round_num:
             metrics = self.evaluate()
-            self._monitor.update_best_result(
-                self.best_results,
-                metrics,
-                results_type='server_global_eval',
-                round_wise_update_key=self._cfg.eval.
-                best_res_update_round_wise_key)
+            self._monitor.update_best_result(self.best_results,
+                                             metrics,
+                                             results_type='server_global_eval')
             formatted_logs = self._monitor.format_eval_res(
                 metrics,
                 rnd=self.state,
@@ -104,12 +101,9 @@ class vFLServer(Server):
             self.broadcast_model_para()
         else:
             metrics = self.evaluate()
-            self._monitor.update_best_result(
-                self.best_results,
-                metrics,
-                results_type='server_global_eval',
-                round_wise_update_key=self._cfg.eval.
-                best_res_update_round_wise_key)
+            self._monitor.update_best_result(self.best_results,
+                                             metrics,
+                                             results_type='server_global_eval')
             formatted_logs = self._monitor.format_eval_res(
                 metrics,
                 rnd=self.state,


### PR DESCRIPTION
## Main changes:
* I make `MetricCalculator` as a sub-module of `Monitor` and fix `update_key` bugs.
* remove redundant code and key of `the larger_the_better` and `the_smaller_the_better`, these would be done in `monitor`.

## Questions:
And I have a question about `ctx` and `monitor`,  as the code block shows:
```python
    def _hook_on_fit_start_calculate_model_size(self, ctx):
        if not isinstance(self.ctx.monitor, Monitor):
            logger.warning(
                f"The trainer {type(self)} does contain a valid monitor, "
                f"this may be caused by initializing trainer subclasses "
                f"without passing a valid monitor instance."
                f"Plz check whether this is you want.")
            return
        if self.ctx.monitor.total_model_size == 0:
            self.ctx.monitor.track_model_size(ctx.models)
```

As `ctx` as args pass to `_hook_on_fit_start_calculate_model_size`, why do we still need use `self.ctx.monitor` rather than `ctx.monitor`? @yxdyc @DavdGao 