### PR TITLE
[Feature] Support more message type in server

### DIFF
--- a/federatedscope/core/auxiliaries/enums.py
+++ b/federatedscope/core/auxiliaries/enums.py
@@ -11,6 +11,12 @@ class MODE:
     FINETUNE = 'finetune'
 
 
+class MSGBUFFER:
+    TRAIN = 'train'
+    EVAL = 'eval'
+    CONSULT = 'consult'
+
+
 class TRIGGER:
     ON_FIT_START = 'on_fit_start'
     ON_EPOCH_START = 'on_epoch_start'


### PR DESCRIPTION
## Our Target
- We are planning to add a consultation stage before training for differential privacy. 
- We decompose it into several PRs to avoid large modification at one time. 

## What's in this PR
- This PR is to support more message types in the server (currently we only support `train` and `eval` in `self.msgbuffer`)
- We add a enumeration class `MSGBUFFER` in `enums.py` to avoid using string directly
- We modify `check_and_move_on` and `check_buffer` fucntions to support more messages. 
- The modification is compatible with previous versions