### PR TITLE
[WIP] Add client manager in server

### DIFF
--- a/federatedscope/attack/worker_as_attacker/server_attacker.py
+++ b/federatedscope/attack/worker_as_attacker/server_attacker.py
@@ -1,3 +1,4 @@
+from federatedscope.core.auxiliaries.enums import STAGE
 from federatedscope.core.workers import Server
 from federatedscope.core.message import Message
 
@@ -284,7 +285,7 @@ class PassiveServer(Server):
                         name='image_state_{}_client_{}.png'.format(
                             message.state, message.sender))
 
-        self.check_and_move_on()
+        self.check_and_move_on(stage=STAGE.TRAIN)
 
 
 class PassivePIAServer(Server):
@@ -359,7 +360,7 @@ class PassivePIAServer(Server):
             # TODO: put this line to `check_and_move_on`
             # currently, no way to know the latest `sender`
             self.aggregator.inc(content)
-        self.check_and_move_on()
+        self.check_and_move_on(stage=STAGE.TRAIN)
 
         if self.state == self.total_round_num:
             self.pia_attacker.train_property_classifier()

--- a/federatedscope/attack/worker_as_attacker/server_attacker.py
+++ b/federatedscope/attack/worker_as_attacker/server_attacker.py
@@ -245,15 +245,15 @@ class PassiveServer(Server):
     def run_reconstruct(self, state_list=None, sender_list=None):
 
         if state_list is None:
-            state_list = self.msg_buffer['train'].keys()
+            state_list = self.msg_buffer[STAGE.TRAIN].keys()
 
         # After FL running, using gradient based reconstruction method to
         # recover client's private training data
         for state in state_list:
             if sender_list is None:
-                sender_list = self.msg_buffer['train'][state].keys()
+                sender_list = self.msg_buffer[STAGE.TRAIN][state].keys()
             for sender in sender_list:
-                content = self.msg_buffer['train'][state][sender]
+                content = self.msg_buffer[STAGE.TRAIN][state][sender]
                 self._reconstruct(model_para=content[1],
                                   batch_size=content[0],
                                   state=state,
@@ -265,9 +265,9 @@ class PassiveServer(Server):
 
         round, sender, content = message.state, message.sender, message.content
         self.sampler.change_state(sender, 'idle')
-        if round not in self.msg_buffer['train']:
-            self.msg_buffer['train'][round] = dict()
-        self.msg_buffer['train'][round][sender] = content
+        if round not in self.msg_buffer[STAGE.TRAIN]:
+            self.msg_buffer[STAGE.TRAIN][round] = dict()
+        self.msg_buffer[STAGE.TRAIN][round][sender] = content
 
         # run reconstruction before the clear of self.msg_buffer
 
@@ -343,9 +343,9 @@ class PassivePIAServer(Server):
 
         round, sender, content = message.state, message.sender, message.content
         self.sampler.change_state(sender, 'idle')
-        if round not in self.msg_buffer['train']:
-            self.msg_buffer['train'][round] = dict()
-        self.msg_buffer['train'][round][sender] = content
+        if round not in self.msg_buffer[STAGE.TRAIN]:
+            self.msg_buffer[STAGE.TRAIN][round] = dict()
+        self.msg_buffer[STAGE.TRAIN][round][sender] = content
 
         # collect the updates
         self.pia_attacker.collect_updates(

--- a/federatedscope/autotune/fedex/server.py
+++ b/federatedscope/autotune/fedex/server.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.special import logsumexp
 
+from federatedscope.core.auxiliaries.enums import STAGE
 from federatedscope.core.message import Message
 from federatedscope.core.workers import Server
 from federatedscope.core.auxiliaries.utils import merge_dict
@@ -204,10 +205,10 @@ class FedExServer(Server):
         round, sender, content = message.state, message.sender, message.content
         self.sampler.change_state(sender, 'idle')
         # For a new round
-        if round not in self.msg_buffer['train'].keys():
-            self.msg_buffer['train'][round] = dict()
+        if round not in self.msg_buffer[STAGE.TRAIN].keys():
+            self.msg_buffer[STAGE.TRAIN][round] = dict()
 
-        self.msg_buffer['train'][round][sender] = content
+        self.msg_buffer[STAGE.TRAIN][round][sender] = content
 
         if self._cfg.federate.online_aggr:
             self.aggregator.inc(tuple(content[0:2]))
@@ -305,7 +306,7 @@ class FedExServer(Server):
             if not check_eval_result:  # in the training process
                 mab_feedbacks = list()
                 # Get all the message
-                train_msg_buffer = self.msg_buffer['train'][self.state]
+                train_msg_buffer = self.msg_buffer[STAGE.TRAIN][self.state]
                 for model_idx in range(self.model_num):
                     model = self.models[model_idx]
                     aggregator = self.aggregators[model_idx]
@@ -363,7 +364,7 @@ class FedExServer(Server):
                         f'----------- Starting a new training round (Round '
                         f'#{self.state}) -------------')
                     # Clean the msg_buffer
-                    self.msg_buffer['train'][self.state - 1].clear()
+                    self.msg_buffer[STAGE.TRAIN][self.state - 1].clear()
 
                     self.broadcast_model_para(
                         msg_type='model_para',

--- a/federatedscope/core/auxiliaries/enums.py
+++ b/federatedscope/core/auxiliaries/enums.py
@@ -11,7 +11,7 @@ class MODE:
     FINETUNE = 'finetune'
 
 
-class MSGBUFFER:
+class STAGE:
     TRAIN = 'train'
     EVAL = 'eval'
     CONSULT = 'consult'

--- a/federatedscope/core/auxiliaries/enums.py
+++ b/federatedscope/core/auxiliaries/enums.py
@@ -11,6 +11,12 @@ class MODE:
     FINETUNE = 'finetune'
 
 
+class MSGBUFFER:
+    TRAIN = 'train'
+    EVAL = 'eval'
+    CONSULT = 'consult'
+
+
 class TRIGGER:
     ON_FIT_START = 'on_fit_start'
     ON_EPOCH_START = 'on_epoch_start'

--- a/federatedscope/core/auxiliaries/enums.py
+++ b/federatedscope/core/auxiliaries/enums.py
@@ -1,4 +1,14 @@
-class MODE:
+class BasicEnum(object):
+    @classmethod
+    def assert_value(cls, value):
+        """
+        Check if the **value** is legal for the given class (If the value equals one of the class attributes)
+        """
+        if not value in [v for k, v in cls.__dict__.items() if not k.startswith('__')]:
+            raise ValueError(f"Value {value} is not in {cls.__name__}.")
+
+
+class MODE(BasicEnum):
     """
 
     Note:
@@ -11,13 +21,13 @@ class MODE:
     FINETUNE = 'finetune'
 
 
-class STAGE:
+class STAGE(BasicEnum):
     TRAIN = 'train'
     EVAL = 'eval'
     CONSULT = 'consult'
 
 
-class TRIGGER:
+class TRIGGER(BasicEnum):
     ON_FIT_START = 'on_fit_start'
     ON_EPOCH_START = 'on_epoch_start'
     ON_BATCH_START = 'on_batch_start'
@@ -36,8 +46,16 @@ class TRIGGER:
         ]
 
 
-class LIFECYCLE:
+class LIFECYCLE(BasicEnum):
     ROUTINE = 'routine'
     EPOCH = 'epoch'
     BATCH = 'batch'
     NONE = None
+
+
+class CLIENT_STATE(BasicEnum):
+    OFFLINE = -1    # not join
+    CONSULTING = 2  # join in and is consulting
+    IDLE = 1        # join in but not working, available for training
+    WORKING = 0     # join in and is working
+    SIDELINE = 0    # join in but won't participate in federated training

--- a/federatedscope/core/auxiliaries/enums.py
+++ b/federatedscope/core/auxiliaries/enums.py
@@ -54,7 +54,7 @@ class LIFECYCLE(BasicEnum):
 
 
 class CLIENT_STATE(BasicEnum):
-    OFFLINE = -1    # not join
+    OFFLINE = -1    # not join in
     CONSULTING = 2  # join in and is consulting
     IDLE = 1        # join in but not working, available for training
     WORKING = 0     # join in and is working

--- a/federatedscope/core/auxiliaries/sampler_builder.py
+++ b/federatedscope/core/auxiliaries/sampler_builder.py
@@ -5,16 +5,15 @@ from federatedscope.core.sampler import UniformSampler, GroupSampler
 logger = logging.getLogger(__name__)
 
 
-def get_sampler(sample_strategy='uniform',
+def get_sampler(sample_strategy,
                 client_num=None,
                 client_info=None,
                 bins=10):
     if sample_strategy == 'uniform':
-        return UniformSampler(client_num=client_num)
+        return UniformSampler()
     elif sample_strategy == 'group':
         return GroupSampler(client_num=client_num,
-                            client_info=client_info,
+                            client_info=client_info['client_resource'],
                             bins=bins)
     else:
-        raise ValueError(
-            f"The sample strategy {sample_strategy} has not been provided.")
+        return None

--- a/federatedscope/core/sampler.py
+++ b/federatedscope/core/sampler.py
@@ -26,7 +26,7 @@ class UniformSampler(Sampler):
         """
         To sample clients
         """
-        sampled_items = np.random.choice(a,
+        sampled_items = np.random.choice(client_idle,
                                          size=size,
                                          replace=False).tolist()
         return sampled_items

--- a/federatedscope/core/sampler.py
+++ b/federatedscope/core/sampler.py
@@ -5,56 +5,31 @@ import numpy as np
 
 class Sampler(ABC):
     """
-    The strategies of sampling clients for each training round
-
-    Arguments:
-        client_state: a dict to manager the state of clients (idle or busy)
+    The strategy of sampling
     """
-    def __init__(self, client_num):
-        self.client_state = np.asarray([1] * (client_num + 1))
-        # Set the state of server (index=0) to 'working'
-        self.client_state[0] = 0
+    def __init__(self):
+        pass
 
     @abstractmethod
-    def sample(self, size):
+    def sample(self, *args, **kwargs):
         raise NotImplementedError
-
-    def change_state(self, indices, state):
-        """
-        To modify the state of clients (idle or working)
-        """
-        if isinstance(indices, list) or isinstance(indices, np.ndarray):
-            all_idx = indices
-        else:
-            all_idx = [indices]
-        for idx in all_idx:
-            if state in ['idle', 'seen']:
-                self.client_state[idx] = 1
-            elif state in ['working', 'unseen']:
-                self.client_state[idx] = 0
-            else:
-                raise ValueError(
-                    f"The state of client should be one of "
-                    f"['idle', 'working', 'unseen], but got {state}")
 
 
 class UniformSampler(Sampler):
     """
-    To uniformly sample the clients from all the idle clients
+    A stateless sampler that samples items uniformly
     """
-    def __init__(self, client_num):
-        super(UniformSampler, self).__init__(client_num)
+    def __init__(self):
+        super(UniformSampler, self).__init__()
 
-    def sample(self, size):
+    def sample(self, client_idle, size, *args,  **kwargs):
         """
         To sample clients
         """
-        idle_clients = np.nonzero(self.client_state)[0]
-        sampled_clients = np.random.choice(idle_clients,
-                                           size=size,
-                                           replace=False).tolist()
-        self.change_state(sampled_clients, 'working')
-        return sampled_clients
+        sampled_items = np.random.choice(a,
+                                         size=size,
+                                         replace=False).tolist()
+        return sampled_items
 
 
 class GroupSampler(Sampler):
@@ -62,22 +37,11 @@ class GroupSampler(Sampler):
     To grouply sample the clients based on their responsiveness (or other
     client information of the clients)
     """
-    def __init__(self, client_num, client_info, bins=10):
-        super(GroupSampler, self).__init__(client_num)
+    def __init__(self, client_info, bins=10):
+        super(GroupSampler, self).__init__()
         self.bins = bins
-        self.update_client_info(client_info)
+        self.client_info = client_info
         self.candidate_iterator = self.partition()
-
-    def update_client_info(self, client_info):
-        """
-        To update the client information
-        """
-        self.client_info = np.asarray(
-            [1.0] + [x for x in client_info
-                     ])  # client_info[0] is preversed for the server
-        assert len(self.client_info) == len(
-            self.client_state
-        ), "The first dimension of client_info is mismatched with client_num"
 
     def partition(self):
         """
@@ -87,7 +51,9 @@ class GroupSampler(Sampler):
         Arguments:
         :returns: a iteration of candidates
         """
-        sorted_index = np.argsort(self.client_info)
+        # sort client_info by xx
+        sorted_index = sorted(self.client_info.keys(), key=lambda x: self.client_info[x])
+        # bin的长度
         num_per_bins = np.int(len(sorted_index) / self.bins)
 
         # grouped clients
@@ -105,11 +71,14 @@ class GroupSampler(Sampler):
 
         return iter(candidates)
 
-    def sample(self, size, shuffle=False):
+    def sample(self, clients_idle, size, perturb=False):
         """
         To sample clients
         """
-        if shuffle:
+        if self.candidate_iterator is None:
+            self.partition()
+
+        if perturb:
             self.candidate_iterator = self.permutation()
 
         sampled_clients = list()
@@ -117,15 +86,14 @@ class GroupSampler(Sampler):
             # To find an idle client
             while True:
                 try:
-                    item = next(self.candidate_iterator)
+                    client_id = next(self.candidate_iterator)
                 except StopIteration:
                     self.candidate_iterator = self.permutation()
-                    item = next(self.candidate_iterator)
+                    client_id = next(self.candidate_iterator)
 
-                if self.client_state[item] == 1:
+                if client_id in clients_idle:
                     break
 
-            sampled_clients.append(item)
-            self.change_state(item, 'working')
+            sampled_clients.append(client_id)
 
         return sampled_clients

--- a/federatedscope/core/workers/client.py
+++ b/federatedscope/core/workers/client.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import pickle
 
+from federatedscope.core.auxiliaries.enums import STAGE
 from federatedscope.core.message import Message
 from federatedscope.core.communication import StandaloneCommManager, \
     gRPCCommManager
@@ -225,12 +226,12 @@ class Client(Worker):
             # A fragment of the shared secret
             state, content, timestamp = message.state, message.content, \
                                         message.timestamp
-            self.msg_buffer['train'][state].append(content)
+            self.msg_buffer[STAGE.TRAIN][state].append(content)
 
-            if len(self.msg_buffer['train']
+            if len(self.msg_buffer[STAGE.TRAIN]
                    [state]) == self._cfg.federate.client_num:
                 # Check whether the received fragments are enough
-                model_list = self.msg_buffer['train'][state]
+                model_list = self.msg_buffer[STAGE.TRAIN][state]
                 sample_size, first_aggregate_model_para = model_list[0]
                 single_model_case = True
                 if isinstance(first_aggregate_model_para, list):
@@ -355,7 +356,7 @@ class Client(Worker):
                     single_model_case else \
                     [model_para_list[frame_idx] for model_para_list in
                      model_para_list_all]
-                self.msg_buffer['train'][self.state] = [(sample_size,
+                self.msg_buffer[STAGE.TRAIN][self.state] = [(sample_size,
                                                          content_frame)]
             else:
                 if self._cfg.asyn.use:

--- a/federatedscope/core/workers/client_manager.py
+++ b/federatedscope/core/workers/client_manager.py
@@ -1,0 +1,193 @@
+import collections
+
+import numpy as np
+
+from federatedscope.core.auxiliaries.sampler_builder import get_sampler
+from federatedscope.core.auxiliaries.enums import CLIENT_STATE
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ClientManager(object):
+    def __init__(self,
+                 num_client,
+                 sample_strategy,
+                 id_client_unseen=[]):
+        self._num_client_join = 0
+        self._num_client_total = num_client
+
+        # the unseen clients indicate the ones that do not contribute to FL
+        # process by training on their local data and uploading their local
+        # model update. The splitting is useful to check participation
+        # generalization gap in
+        # [ICLR'22, What Do We Mean by Generalization in Federated Learning?]
+        self._num_client_unseen = len(id_client_unseen)
+        self._id_client_unseen = id_client_unseen
+
+        # TODO: achieve by a two-leveled index rather than saving twice
+        # Used to maintain the information collected from the clients
+        self._info_by_client = collections.defaultdict(dict)
+        self._info_by_key = collections.defaultdict(dict)
+
+        # Record the state of the clients (client_id counts from 1)
+        self._state_client = {client_id: CLIENT_STATE.OFFLINE for client_id in range(1, self._num_client_total+1)}
+
+        self.sampler = None
+        self.sample_strategy = sample_strategy
+
+    def __assert_client(self, client_id):
+        """
+        Check if the client_id is legal.
+        """
+        if client_id >= 1 and client_id <= self._num_client_join + 1:
+            pass
+        else:
+            raise IndexError(f"Client ID {client_id} doesn't exist.")
+
+    @property
+    def _num_join_client(self):
+        return self._num_join_client
+
+    def join_in(self, client_id):
+        """
+        Register the client as online
+        """
+        self.__assert_client(client_id)
+
+        # Step into consulting (exchange information between server and client)
+        self._state_client[client_id] = CLIENT_STATE.CONSULTING
+        self._num_join_client += 1
+
+    def set_offline(self, client_id):
+        """
+        Set the state of the client as CLIENT_STATE.OFFLINE
+        """
+        self.__assert_client(client_id)
+
+        self.change_state(client_id, CLIENT_STATE.OFFLINE)
+        self._num_join_client -= 1
+
+    def finish_consult(self, client_id):
+        """
+        Set the state of the client that finishes consulting as CLIENT_STATE.IDLE
+        """
+        self.change_state(client_id, CLIENT_STATE.IDLE)
+
+    def check_client_join_in(self):
+        """
+        Check if enough clients has joined in.
+        """
+        return self._num_join_client == self._num_client
+
+    def check_client_info(self):
+        """
+        Check if enough information is collected from the clients
+        """
+        return len(self._info_by_client) == self._num_client
+
+    def check_client_consult(self):
+        """
+        Check if all clients finish requiring information from the server (The state is CLIENT_STATE.IDLE)
+        """
+        return len(self.get_idle_client()) == self._num_client
+
+    def update_client_info(self, client_id, info: dict):
+        """
+        Update client information in the manager.
+        """
+        if client_id in self._info_by_client:
+            logger.info(f"Information of Client #{client_id} is updated by {info}.")
+        self._info_by_client.update(info)
+
+        for k, v in info.items():
+            self._info_by_key[k][client_id] = v
+
+    def del_client_info(self, client_id):
+        """
+        Delete the client information.
+        """
+        if client_id in self._info_by_client:
+            del self._info_by_client[client_id]
+            for k in self._info_by_client:
+                if client_id in self._info_by_client[k]:
+                    del self._info_by_client[k][client_id]
+
+    def get_info_by_client(self, client_id):
+        """
+        Get the client information by client_id
+        """
+        return self._info_by_client.get(client_id, None)
+
+    def get_info_by_key(self, key):
+        """
+        Get the client information by key
+        """
+        return self._info_by_client.get(key, None)
+
+    def change_state(self, indices, state):
+        """
+        To modify the state of clients (idle or working)
+        """
+        CLIENT_STATE.assert_value(state)
+
+        if isinstance(indices, list) or isinstance(indices, np.ndarray):
+            client_idx = indices
+        else:
+            client_idx = [indices]
+
+        for client_id in client_idx:
+            self._state_client[client_id] = state
+
+    def get_client_by_state(self, state):
+        CLIENT_STATE.assert_value(state)
+
+        return [client_id for client_id, client_state in self._state_client if client_state == state]
+
+    def get_consult_client(self):
+        """
+        Return all the clients with state CLIENT_STATE.CONSULTING
+        """
+        self.get_client_by_state(CLIENT_STATE.CONSULTING)
+
+    def get_idle_client(self):
+        """
+        Return all the clients with state CLIENT_STATE.IDLE
+        """
+        return self.get_client_by_state(CLIENT_STATE.IDLE)
+
+    def init_sampler(self):
+        """
+        Considering the sampling strategy may need client information, we should
+        initialize it after finishing client information collection, or
+        re-initialize it after updating client information.
+        """
+        # To sample clients during training
+        self.sampler = get_sampler(
+            sample_strategy=self.sample_strategy,
+            client_num=self._num_client_total,
+            client_info=self._info_by_key
+        )
+
+    def sample(self, size, perturb=False):
+        """Sample idle clients with the specific sampler
+
+        Args:
+            size: the number of sample size
+            perturb: if perturb the clients before sampling
+
+        Returns:
+            index of the sampled clients
+        """
+        if self.sampler is None:
+            # When we call the function sample, we default that all client information have been collected.
+            self.init_sampler()
+
+        # Obtain the idle clients
+        clients_idle = self.get_idle_client()
+        # Sampling
+        clients_sampled = self.sampler.sample(clients_idle, size, perturb)
+        # Change state for the sampled clients
+        self.change_state(clients_sampled, CLIENT_STATE.WORKING)
+        return clients_sampled

--- a/federatedscope/gfl/fedsageplus/worker.py
+++ b/federatedscope/gfl/fedsageplus/worker.py
@@ -121,7 +121,7 @@ class FedSagePlusServer(Server):
                     gen_grad[key].cpu())
         self.check_and_move_on()
 
-    def check_and_move_on(self, check_eval_result=False):
+    def check_and_move_on(self, check_eval_result=False, **kwargs):
         client_IDs = [i for i in range(1, self.client_num + 1)]
 
         if check_eval_result:

--- a/federatedscope/gfl/gcflplus/worker.py
+++ b/federatedscope/gfl/gcflplus/worker.py
@@ -3,6 +3,7 @@ import logging
 import copy
 import numpy as np
 
+from federatedscope.core.auxiliaries.enums import STAGE
 from federatedscope.core.message import Message
 from federatedscope.core.workers.server import Server
 from federatedscope.core.workers.client import Client
@@ -44,7 +45,7 @@ class GCFLPlusServer(Server):
         max_norm = -np.inf
         cluster_dWs = []
         for key in cluster:
-            content = self.msg_buffer['train'][self.state][key]
+            content = self.msg_buffer[STAGE.TRAIN][self.state][key]
             _, model_para, client_dw, _ = content
             dW = {}
             for k in model_para.keys():
@@ -71,7 +72,7 @@ class GCFLPlusServer(Server):
 
             if not check_eval_result:  # in the training process
                 # Get all the message
-                train_msg_buffer = self.msg_buffer['train'][self.state]
+                train_msg_buffer = self.msg_buffer[STAGE.TRAIN][self.state]
                 for model_idx in range(self.model_num):
                     model = self.models[model_idx]
                     aggregator = self.aggregators[model_idx]
@@ -135,7 +136,7 @@ class GCFLPlusServer(Server):
                     for cluster in self.cluster_indices:
                         msg_list = list()
                         for key in cluster:
-                            content = self.msg_buffer['train'][self.state -
+                            content = self.msg_buffer[STAGE.TRAIN][self.state -
                                                                1][key]
                             train_data_size, model_para, client_dw,  \
                                 convGradsNorm = content
@@ -161,7 +162,7 @@ class GCFLPlusServer(Server):
                         f'----------- Starting a new traininground(Round '
                         f'#{self.state}) -------------')
                     # Clean the msg_buffer
-                    self.msg_buffer['train'][self.state - 1].clear()
+                    self.msg_buffer[STAGE.TRAIN][self.state - 1].clear()
 
                 else:
                     # Final Evaluate


### PR DESCRIPTION
## Target
- We are planning to add a consultation stage before training for differential privacy and other algorithms.
- We decompose it into several PRs to avoid large modification at one time.

## What's in this PR
- This PR is to add client manager in server, which is responsible for
  - Maintain the status of clients, e.g., working, idle or unseen (in training)
  - Manage the clients, including registration, client-related information storage (client_resource, [TODO]join_in_info)

## Why
- Currently, the client management is too decentralized. For example, 
  - `self.join_in_info` stores the client information, 
  - `self.id_unseen_client` records the unseen clients during training and 
  - `self.sampler` records the status of the clients (Maybe sampler should be in charge of the client status)