### PR TITLE
set pin_memory to False to avoid OOM

### DIFF
--- a/federatedscope/core/configs/cfg_data.py
+++ b/federatedscope/core/configs/cfg_data.py
@@ -40,7 +40,7 @@ def extend_data_cfg(cfg):
     cfg.dataloader.shuffle = True
     cfg.dataloader.num_workers = 0
     cfg.dataloader.drop_last = False
-    cfg.dataloader.pin_memory = True
+    cfg.dataloader.pin_memory = False
     # GFL: graphsaint DataLoader
     cfg.dataloader.walk_length = 2
     cfg.dataloader.num_steps = 30

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ Then you can launch the participants (i.e., `python federatedscope/main.py --cfg
 
 Also, users can run distribute mode with other provided datasets and models. Take training ConvNet on FEMNIST as an example:
 ```shell script
-bash distributed_scripts/run_distributed_conv_femnist.sh 
+bash distributed_scripts/run_distributed_conv_femnist.sh
 ```
 
 ### Federated Learning in Computer Vision (FL-CV)


### PR DESCRIPTION
`pin_memory=True`

WARNING

Using [automatic memory pinning](https://pytorch.org/docs/stable/data.html#memory-pinning) (i.e., setting pin_memory=True), which enables fast data transfer to CUDA-enabled GPUs.