### PR TITLE
Change default value of msg.content to 'None'

### DIFF
--- a/federatedscope/core/message.py
+++ b/federatedscope/core/message.py
@@ -21,7 +21,7 @@ class Message(object):
                  sender=0,
                  receiver=0,
                  state=0,
-                 content=None,
+                 content='None',
                  timestamp=0,
                  strategy=None):
         self._msg_type = msg_type


### PR DESCRIPTION
Change the default value of `msg.content` from None to 'None' to tackle the issue caused by the fact that grpc cannot support NoneType. (Fix #488 )