### PR TITLE
Add random forest in VFL

### DIFF
--- a/federatedscope/autotune/baseline/fedhpo_vfl.yaml
+++ b/federatedscope/autotune/baseline/fedhpo_vfl.yaml
@@ -35,6 +35,8 @@ vertical:
   key_size: 256
   dims: [7, 14]
   algo: 'xgb'
+  data_size_for_debug: 1500
+  feature_subsample_ratio: 1.0
 eval:
   freq: 5
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/core/auxiliaries/model_builder.py
+++ b/federatedscope/core/auxiliaries/model_builder.py
@@ -185,7 +185,9 @@ def get_model(model_config, local_data=None, backend='torch'):
     elif model_config.type.lower() in ['vmfnet', 'hmfnet']:
         from federatedscope.mf.model.model_builder import get_mfnet
         model = get_mfnet(model_config, input_shape)
-    elif model_config.type.lower() in ['xgb_tree', 'gbdt_tree']:
+    elif model_config.type.lower() in [
+            'xgb_tree', 'gbdt_tree', 'random_forest'
+    ]:
         from federatedscope.vertical_fl.model.model_builder import \
             get_tree_model
         model = get_tree_model(model_config)

--- a/federatedscope/core/auxiliaries/worker_builder.py
+++ b/federatedscope/core/auxiliaries/worker_builder.py
@@ -54,7 +54,7 @@ def get_client_cls(cfg):
         if cfg.vertical.algo == 'lr':
             from federatedscope.vertical_fl.worker import vFLClient
             return vFLClient
-        elif cfg.vertical.algo in ['xgb', 'gbdt']:
+        elif cfg.vertical.algo in ['xgb', 'gbdt', 'rf']:
             from federatedscope.vertical_fl.xgb_base.worker import XGBClient
             return XGBClient
         else:
@@ -157,7 +157,7 @@ def get_server_cls(cfg):
         if cfg.vertical.algo == 'lr':
             from federatedscope.vertical_fl.worker import vFLServer
             return vFLServer
-        elif cfg.vertical.algo in ['xgb', 'gbdt']:
+        elif cfg.vertical.algo in ['xgb', 'gbdt', 'rf']:
             from federatedscope.vertical_fl.xgb_base.worker import XGBServer
             return XGBServer
         else:

--- a/federatedscope/core/configs/cfg_fl_setting.py
+++ b/federatedscope/core/configs/cfg_fl_setting.py
@@ -76,11 +76,16 @@ def extend_fl_setting_cfg(cfg):
     cfg.vertical.dims = [5, 10]  # TODO: we need to explain dims
     cfg.vertical.encryption = 'paillier'
     cfg.vertical.key_size = 3072
-    cfg.vertical.algo = 'lr'  # ['lr', 'xgb']
+    cfg.vertical.algo = 'lr'  # ['lr', 'xgb', 'gbdt', 'rf']
+    cfg.vertical.feature_subsample_ratio = 1.0
     cfg.vertical.protect_object = ''  # feature_order, TODO: add more
-    cfg.vertical.protect_method = ''  # dp
+    cfg.vertical.protect_method = ''  # dp, op_boost
     cfg.vertical.protect_args = []
     # Default values for 'dp': {'bucket_num':100, 'epsilon':None}
+    # Default values for 'op_boost': {'algo':'global', 'lower_bound':1,
+    #                                 'upper_bound':100, 'epsilon':2}
+    cfg.vertical.data_size_for_debug = 0  # use a subset for debug in vfl,
+    # 0 indicates using the entire dataset (disable debug mode)
 
     # --------------- register corresponding check function ----------
     cfg.register_cfg_check_fun(assert_fl_setting_cfg)
@@ -227,6 +232,12 @@ def assert_fl_setting_cfg(cfg):
                            f"but got {cfg.model.type}. Therefore "
                            f"cfg.model.type is changed to 'gbdt_tree' here")
             cfg.model.type = 'gbdt_tree'
+
+        if not (cfg.vertical.feature_subsample_ratio > 0
+                and cfg.vertical.feature_subsample_ratio <= 1.0):
+            raise ValueError(f'The value of vertical.feature_subsample_ratio '
+                             f'must be in (0, 1.0], but got '
+                             f'{cfg.vertical.feature_subsample_ratio}')
 
 
 register_config("fl_setting", extend_fl_setting_cfg)

--- a/federatedscope/vertical_fl/dataloader/dataloader.py
+++ b/federatedscope/vertical_fl/dataloader/dataloader.py
@@ -37,6 +37,7 @@ def load_vertical_data(config=None, generate=False):
                                 feature_partition=config.vertical.dims,
                                 tr_frac=config.data.splits[0],
                                 algo=config.vertical.algo,
+                                debug_size=config.vertical.data_size_for_debug,
                                 download=True,
                                 seed=1234,
                                 args=args)

--- a/federatedscope/vertical_fl/dataloader/utils.py
+++ b/federatedscope/vertical_fl/dataloader/utils.py
@@ -11,7 +11,7 @@ def batch_iter(data, batch_size, shuffled=True):
         batch_size (int): the batch size
         shuffled (bool): whether to shuffle the data at the start of each epoch
     :returns: sample index, batch of x, batch_of y
-    :rtype: int, ndarray, ndarry
+    :rtype: int, ndarray, ndarray
     """
 
     assert 'x' in data and 'y' in data
@@ -28,3 +28,58 @@ def batch_iter(data, batch_size, shuffled=True):
             end_index = min(data_size, (batch + 1) * batch_size)
             sample_index = shuffled_index[start_index:end_index]
             yield sample_index, data_x[sample_index], data_y[sample_index]
+
+
+class VerticalDataSampler(object):
+    """
+    VerticalDataSampler is used to sample a subset from data
+
+    Arguments:
+        data(dict): data
+        replace (bool): Whether the sample is with or without replacement
+    """
+    def __init__(self,
+                 data,
+                 replace=False,
+                 use_full_trainset=True,
+                 feature_frac=1.0):
+        assert 'x' in data
+        self.data_x = data['x']
+        self.data_y = data['y'] if 'y' in data else None
+        self.data_size = self.data_x.shape[0]
+        self.feature_size = self.data_x.shape[1]
+        self.replace = replace
+        self.use_full_trainset = use_full_trainset
+        self.selected_feature_num = max(1,
+                                        int(self.feature_size * feature_frac))
+        self.selected_feature_index = None
+
+    def sample_data(self, sample_size, index=None):
+
+        # use the entire dataset
+        if self.use_full_trainset:
+            return range(len(self.data_x)), self.data_x, self.data_y
+
+        if index is not None:
+            sampled_x = self.data_x[index]
+            sampled_y = self.data_y[index] if self.data_y is not None else None
+        else:
+            sample_size = min(sample_size, self.data_size)
+            index = np.random.choice(a=self.data_size,
+                                     size=sample_size,
+                                     replace=self.replace)
+            sampled_x = self.data_x[index]
+            sampled_y = self.data_y[index] if self.data_y is not None else None
+
+        return index, sampled_x, sampled_y
+
+    def sample_feature(self, x):
+        if self.selected_feature_num == self.feature_size:
+            return range(x.shape[-1]), x
+        else:
+            feature_index = np.random.choice(a=self.feature_size,
+                                             size=self.selected_feature_num,
+                                             replace=False)
+            self.selected_feature_index = feature_index
+
+        return feature_index, x[:, feature_index]

--- a/federatedscope/vertical_fl/dataset/abalone.py
+++ b/federatedscope/vertical_fl/dataset/abalone.py
@@ -2,6 +2,7 @@ import logging
 import os
 import os.path as osp
 
+import numpy as np
 import pandas as pd
 from torchvision.datasets.utils import download_and_extract_archive
 
@@ -43,7 +44,9 @@ class Abalone(object):
         args (dict): set Ture or False to decide whether
                      to normalize or standardize the data or not,
                      e.g., {'normalization': False, 'standardization': False}
-        algo(str): the running model, 'lr' or 'xgb'
+        algo(str): the running model, 'lr'/'xgb'/'gbdt'/'rf'
+        debug_size(int): use a subset for debug,
+                                  0 for using entire dataset
         download (bool): indicator to download dataset
         seed: a random seed
     """
@@ -58,6 +61,7 @@ class Abalone(object):
                  args,
                  algo=None,
                  tr_frac=0.8,
+                 debug_size=0,
                  download=True,
                  seed=123):
         self.root = root
@@ -67,6 +71,7 @@ class Abalone(object):
         self.seed = seed
         self.args = args
         self.algo = algo
+        self.data_size_for_debug = debug_size
         self.data_dict = {}
         self.data = {}
 
@@ -84,6 +89,10 @@ class Abalone(object):
         file = osp.join(fpath, self.raw_file)
         data = self._read_raw(file)
         data = self._process(data)
+        if self.data_size_for_debug != 0:
+            subset_size = min(len(data), self.data_size_for_debug)
+            np.random.shuffle(data)
+            data = data[:subset_size]
         train_num = int(self.tr_frac * len(data))
         self.data_dict['train'] = data[:train_num]
         self.data_dict['test'] = data[train_num:]

--- a/federatedscope/vertical_fl/dataset/blog.py
+++ b/federatedscope/vertical_fl/dataset/blog.py
@@ -45,7 +45,9 @@ class Blog(object):
         args (dict): set Ture or False to decide whether
                      to normalize or standardize the data or not,
                      e.g., {'normalization': False, 'standardization': False}
-        algo(str): the running model, 'lr' or 'xgb'
+        algo(str): the running model, 'lr'/'xgb'/'gbdt'/'rf'
+        debug_size(int): use a subset for debug,
+                                  0 for using entire dataset
         download (bool): indicator to download dataset
         seed: a random seed
     """
@@ -60,6 +62,7 @@ class Blog(object):
                  args,
                  algo=None,
                  tr_frac=0.8,
+                 debug_size=0,
                  download=True,
                  seed=123):
         super(Blog, self).__init__()
@@ -70,6 +73,7 @@ class Blog(object):
         self.seed = seed
         self.args = args
         self.algo = algo
+        self.data_size_for_debug = debug_size
         self.data_dict = {}
         self.data = {}
 
@@ -97,6 +101,11 @@ class Blog(object):
                 flag = 1
             else:
                 test_data = np.concatenate((test_data, f_data), axis=0)
+
+        if self.data_size_for_debug != 0:
+            subset_size = min(len(train_data), self.data_size_for_debug)
+            np.random.shuffle(train_data)
+            train_data = train_data[:subset_size]
 
         self.data_dict['train'] = train_data
         self.data_dict['test'] = test_data

--- a/federatedscope/vertical_fl/dataset/credit.py
+++ b/federatedscope/vertical_fl/dataset/credit.py
@@ -26,7 +26,9 @@ class Credit(object):
         args (dict): set Ture or False to decide whether
                      to normalize or standardize the data or not,
                      e.g., {'normalization': False, 'standardization': False}
-        algo(str): the running model, 'lr' or 'xgb'
+        algo(str): the running model, 'lr'/'xgb'/'gbdt'/'rf'
+        debug_size(int): use a subset for debug,
+                                  0 for using entire dataset
         download (bool): indicator to download dataset
         seed: a random seed
     """
@@ -41,6 +43,7 @@ class Credit(object):
                  args,
                  algo=None,
                  tr_frac=0.8,
+                 debug_size=0,
                  download=True,
                  seed=123):
         super(Credit, self).__init__()
@@ -51,6 +54,7 @@ class Credit(object):
         self.seed = seed
         self.args = args
         self.algo = algo
+        self.data_size_for_debug = debug_size
         self.data_dict = {}
         self.data = {}
 
@@ -89,6 +93,11 @@ class Credit(object):
         sample_idx = balance_sample(sample_size, data[:, 0])
         data = data[sample_idx]
         # '''
+
+        if self.data_size_for_debug != 0:
+            subset_size = min(len(data), self.data_size_for_debug)
+            np.random.shuffle(data)
+            data = data[:subset_size]
 
         train_num = int(self.tr_frac * len(data))
 

--- a/federatedscope/vertical_fl/loss/binary_cls.py
+++ b/federatedscope/vertical_fl/loss/binary_cls.py
@@ -6,25 +6,39 @@ class BinaryClsLoss(object):
     y = {1, 0}
     L = -yln(p)-(1-y)ln(1-p)
     """
-    def __init__(self, cal_hess=True):
-        self.cal_hess = cal_hess
+    def __init__(self, model_type):
+        self.cal_hess = model_type in ['xgb_tree']
+        self.cal_sigmoid = model_type in ['xgb_tree', 'gbdt_tree']
+        self.merged_mode = 'mean' if model_type in ['random_forest'] else 'sum'
+
+    def _sigmoid(self, y_pred):
+        return 1.0 / (1.0 + np.exp(-y_pred))
+
+    def _process_y_pred(self, y_pred):
+        if self.merged_mode == 'mean':
+            y_pred = np.mean(y_pred, axis=0)
+        else:
+            y_pred = np.sum(y_pred, axis=0)
+
+        if self.cal_sigmoid:
+            y_pred = self._sigmoid(y_pred)
+
+        return y_pred
 
     def get_metric(self, y, y_pred):
-        pred_prob = 1.0 / (1.0 + np.exp(-y_pred))
-        pred_prob[pred_prob >= 0.5] = 1.
-        pred_prob[pred_prob < 0.5] = 0
-        acc = np.sum(pred_prob == y) / len(y)
+        y_pred = self._process_y_pred(y_pred)
+        y_pred = (y_pred >= 0.5).astype(np.float32)
+        acc = np.sum(y_pred == y) / len(y)
         return {'acc': acc}
 
     def get_loss(self, y, y_pred):
-        y_pred = 1.0 / (1.0 + np.exp(-y_pred))
-        res = np.mean(-y * np.log(y_pred))
+        y_pred = self._process_y_pred(y_pred)
+        res = np.mean(-y * np.log(y_pred + 1e-7))
         return res
 
-    def get_grad_and_hess(self, y, pred):
-        pred = np.asarray(pred)
+    def get_grad_and_hess(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         y = np.array(y)
-        prob = 1.0 / (1.0 + np.exp(-pred))
-        grad = prob - y
-        hess = prob * (1.0 - prob) if self.cal_hess else None
+        grad = y_pred - y
+        hess = y_pred * (1.0 - y_pred) if self.cal_hess else None
         return grad, hess

--- a/federatedscope/vertical_fl/loss/regression.py
+++ b/federatedscope/vertical_fl/loss/regression.py
@@ -2,16 +2,28 @@ import numpy as np
 
 
 class RegressionMAELoss(object):
-    def __init__(self, cal_hess=True):
-        self.cal_hess = cal_hess
+    def __init__(self, model_type):
+        self.cal_hess = model_type in ['xgb_tree']
+        self.merged_mode = 'mean' if model_type in ['random_forest'] else 'sum'
+
+    def _process_y_pred(self, y_pred):
+        if self.merged_mode == 'mean':
+            y_pred = np.mean(y_pred, axis=0)
+        else:
+            y_pred = np.sum(y_pred, axis=0)
+
+        return y_pred
 
     def get_metric(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         return {'mae': np.mean(np.abs(y - y_pred))}
 
     def get_loss(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         return np.mean(np.abs(y - y_pred))
 
     def get_grad_and_hess(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         x = y_pred - y
         grad = np.sign(x)
         hess = np.zeros_like(x) if self.cal_hess else None
@@ -19,16 +31,28 @@ class RegressionMAELoss(object):
 
 
 class RegressionMSELoss(object):
-    def __init__(self, cal_hess=True):
-        self.cal_hess = cal_hess
+    def __init__(self, model_type):
+        self.cal_hess = model_type in ['xgb_tree']
+        self.merged_mode = 'mean' if model_type in ['random_forest'] else 'sum'
+
+    def _process_y_pred(self, y_pred):
+        if self.merged_mode == 'mean':
+            y_pred = np.mean(y_pred, axis=0)
+        else:
+            y_pred = np.sum(y_pred, axis=0)
+
+        return y_pred
 
     def get_metric(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         return {'mse': np.mean((y - y_pred)**2)}
 
     def get_loss(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         return np.mean((y - y_pred)**2)
 
     def get_grad_and_hess(self, y, y_pred):
+        y_pred = self._process_y_pred(y_pred)
         x = y_pred - y
         grad = x
         hess = np.ones_like(x) if self.cal_hess else None

--- a/federatedscope/vertical_fl/loss/utils.py
+++ b/federatedscope/vertical_fl/loss/utils.py
@@ -1,10 +1,10 @@
-def get_vertical_loss(loss_type, cal_hess=True):
+def get_vertical_loss(loss_type, model_type):
     if loss_type == 'CrossEntropyLoss':
         from federatedscope.vertical_fl.loss import BinaryClsLoss
-        return BinaryClsLoss(cal_hess=cal_hess)
+        return BinaryClsLoss(model_type=model_type)
     elif loss_type == 'RegressionMSELoss':
         from federatedscope.vertical_fl.loss import RegressionMSELoss
-        return RegressionMSELoss(cal_hess=cal_hess)
+        return RegressionMSELoss(model_type=model_type)
     elif loss_type == 'RegressionMAELoss':
         from federatedscope.vertical_fl.loss import RegressionMAELoss
-        return RegressionMAELoss(cal_hess=cal_hess)
+        return RegressionMAELoss(model_type=model_type)

--- a/federatedscope/vertical_fl/model/Tree.py
+++ b/federatedscope/vertical_fl/model/Tree.py
@@ -135,7 +135,8 @@ class DecisionTree(Tree):
 
     def cal_gini(self, split_idx, y, indicator):
         if self._check_same_label(y, indicator):
-            return np.float('inf')
+            # Return the maximum gini value
+            return 1.0
 
         left_child_indicator = indicator * np.concatenate(
             [np.ones(split_idx),
@@ -147,7 +148,7 @@ class DecisionTree(Tree):
         return np.sum(left_child_indicator) / total_num * left_gini + sum(
             right_child_indicator) / total_num * right_gini
 
-    def cal_sse(self, split_idx, y, indicator):
+    def cal_sum_of_square_mean_err(self, split_idx, y, indicator):
         left_child_indicator = indicator * np.concatenate(
             [np.ones(split_idx),
              np.zeros(len(y) - split_idx)])
@@ -164,7 +165,7 @@ class DecisionTree(Tree):
         if self.task_type == 'classification':
             return self.cal_gini(split_idx, y, indicator)
         elif self.task_type == 'regression':
-            return self.cal_sse(split_idx, y, indicator)
+            return self.cal_sum_of_square_mean_err(split_idx, y, indicator)
         else:
             raise ValueError(f'Task type error: {self.task_type}')
 

--- a/federatedscope/vertical_fl/model/__init__.py
+++ b/federatedscope/vertical_fl/model/__init__.py
@@ -1,4 +1,4 @@
 from federatedscope.vertical_fl.model.Tree \
-    import MultipleXGBTrees, MultipleGBDTTrees
+    import MultipleXGBTrees, MultipleGBDTTrees, RandomForest
 
-__all__ = ['MultipleXGBTrees', 'MultipleGBDTTrees']
+__all__ = ['MultipleXGBTrees', 'MultipleGBDTTrees', 'RandomForest']

--- a/federatedscope/vertical_fl/model/model_builder.py
+++ b/federatedscope/vertical_fl/model/model_builder.py
@@ -1,8 +1,8 @@
 from federatedscope.vertical_fl.model \
-    import MultipleXGBTrees, MultipleGBDTTrees
+    import MultipleXGBTrees, MultipleGBDTTrees, RandomForest
 
 
-def get_tree_model(model_config):
+def get_tree_model(model_config, criterion_type=None):
 
     if model_config.type.lower() == 'xgb_tree':
         return MultipleXGBTrees(max_depth=model_config.max_tree_depth,
@@ -14,3 +14,8 @@ def get_tree_model(model_config):
                                  lambda_=model_config.lambda_,
                                  gamma=model_config.gamma,
                                  num_of_trees=model_config.num_of_trees)
+    elif model_config.type.lower() == 'random_forest':
+        return RandomForest(max_depth=model_config.max_tree_depth,
+                            lambda_=model_config.lambda_,
+                            gamma=model_config.gamma,
+                            num_of_trees=model_config.num_of_trees)

--- a/federatedscope/vertical_fl/trainer/__init__.py
+++ b/federatedscope/vertical_fl/trainer/__init__.py
@@ -1,9 +1,10 @@
 from federatedscope.vertical_fl.trainer.trainer import VerticalTrainer
 from federatedscope.vertical_fl.trainer.feature_order_protected_trainer \
-    import FeatureOrderProtectedTrainer
+    import createFeatureOrderProtectedTrainer
 from federatedscope.vertical_fl.trainer.random_forest_trainer import \
     RandomForestTrainer
 
 __all__ = [
-    'VerticalTrainer', 'FeatureOrderProtectedTrainer', 'RandomForestTrainer'
+    'VerticalTrainer', 'createFeatureOrderProtectedTrainer',
+    'RandomForestTrainer'
 ]

--- a/federatedscope/vertical_fl/trainer/__init__.py
+++ b/federatedscope/vertical_fl/trainer/__init__.py
@@ -1,3 +1,9 @@
 from federatedscope.vertical_fl.trainer.trainer import VerticalTrainer
 from federatedscope.vertical_fl.trainer.feature_order_protected_trainer \
     import FeatureOrderProtectedTrainer
+from federatedscope.vertical_fl.trainer.random_forest_trainer import \
+    RandomForestTrainer
+
+__all__ = [
+    'VerticalTrainer', 'FeatureOrderProtectedTrainer', 'RandomForestTrainer'
+]

--- a/federatedscope/vertical_fl/trainer/feature_order_protected_trainer.py
+++ b/federatedscope/vertical_fl/trainer/feature_order_protected_trainer.py
@@ -1,236 +1,245 @@
 import numpy as np
-from federatedscope.vertical_fl.trainer.trainer import VerticalTrainer
 
 
-class FeatureOrderProtectedTrainer(VerticalTrainer):
-    def __init__(self, model, data, device, config, monitor):
-        super(FeatureOrderProtectedTrainer,
-              self).__init__(model, data, device, config, monitor)
+def createFeatureOrderProtectedTrainer(cls, model, data, device, config,
+                                       monitor):
+    class FeatureOrderProtectedTrainer(cls):
+        def __init__(self, model, data, device, config, monitor):
+            super(FeatureOrderProtectedTrainer,
+                  self).__init__(model, data, device, config, monitor)
 
-        assert config.vertical.protect_method != '', \
-            "Please specify the adopted method for protecting feature order"
-        args = config.vertical.protect_args[0] if len(
-            config.vertical.protect_args) > 0 else {}
+            assert config.vertical.protect_method != '', \
+                "Please specify the method for protecting feature order"
+            args = config.vertical.protect_args[0] if len(
+                config.vertical.protect_args) > 0 else {}
 
-        if config.vertical.protect_method == 'dp':
-            self.bucket_num = args.get('bucket_num', 100)
-            self.epsilon = args.get('epsilon', None)
-            self.protect_funcs = self._protect_via_dp
-            self.split_value = None
-        elif config.vertical.protect_method == 'op_boost':
-            self.algo = args.get('algo', 'global')
-            self.protect_funcs = self._protect_via_op_boost
-            self.lower_bound = args.get('lower_bound', 1)
-            self.upper_bound = args.get('upper_bound', 100)
-            if self.algo == 'global':
-                self.epsilon = args.get('epsilon', 2)
-            elif self.algo == 'adjusting':
-                self.epsilon_prt = args.get('epsilon_prt', 2)
-                self.epsilon_ner = args.get('epsilon_ner', 2)
-                self.partition_num = args.get('partition_num', 10)
+            if config.vertical.protect_method == 'dp':
+                self.bucket_num = args.get('bucket_num', 100)
+                self.epsilon = args.get('epsilon', None)
+                self.protect_funcs = self._protect_via_dp
+                self.split_value = None
+            elif config.vertical.protect_method == 'op_boost':
+                self.algo = args.get('algo', 'global')
+                self.protect_funcs = self._protect_via_op_boost
+                self.lower_bound = args.get('lower_bound', 1)
+                self.upper_bound = args.get('upper_bound', 100)
+                if self.algo == 'global':
+                    self.epsilon = args.get('epsilon', 2)
+                elif self.algo == 'adjusting':
+                    self.epsilon_prt = args.get('epsilon_prt', 2)
+                    self.epsilon_ner = args.get('epsilon_ner', 2)
+                    self.partition_num = args.get('partition_num', 10)
+                else:
+                    raise ValueError
             else:
-                raise ValueError
-        else:
-            raise ValueError(f"The method {args['method']} is not provided")
+                raise ValueError(
+                    f"The method {args['method']} is not provided")
 
-    def get_feature_value(self, feature_idx, value_idx):
-        if not hasattr(self, 'split_value') or self.split_value is None:
-            return super().get_feature_value(feature_idx=feature_idx,
-                                             value_idx=value_idx)
+        def get_feature_value(self, feature_idx, value_idx):
+            if not hasattr(self, 'split_value') or self.split_value is None:
+                return super().get_feature_value(feature_idx=feature_idx,
+                                                 value_idx=value_idx)
 
-        return self.split_value[feature_idx][value_idx]
+            return self.split_value[feature_idx][value_idx]
 
-    def _bucketize(self, feature_order, bucket_size, bucket_num):
-        bucketized_feature_order = list()
-        for bucket_idx in range(bucket_num):
-            start = bucket_idx * bucket_size
-            end = min((bucket_idx + 1) * bucket_size, len(feature_order))
-            bucketized_feature_order.append(feature_order[start:end])
-        return bucketized_feature_order
+        def _bucketize(self, feature_order, bucket_size, bucket_num):
+            bucketized_feature_order = list()
+            for bucket_idx in range(bucket_num):
+                start = bucket_idx * bucket_size
+                end = min((bucket_idx + 1) * bucket_size, len(feature_order))
+                bucketized_feature_order.append(feature_order[start:end])
+            return bucketized_feature_order
 
-    def _processed_data(self, data):
-        min_value = np.min(data, axis=0)
-        max_value = np.max(data, axis=0)
-        # To avoid data_max[i] == data_min[i],
-        for i in range(data.shape[1]):
-            if max_value[i] == min_value[i]:
-                max_value[i] += 1
-        return np.round(self.lower_bound + (data - min_value) /
-                        (max_value - min_value) *
-                        (self.upper_bound - self.lower_bound))
+        def _processed_data(self, data):
+            min_value = np.min(data, axis=0)
+            max_value = np.max(data, axis=0)
+            # To avoid data_max[i] == data_min[i],
+            for i in range(data.shape[1]):
+                if max_value[i] == min_value[i]:
+                    max_value[i] += 1
+            return np.round(self.lower_bound + (data - min_value) /
+                            (max_value - min_value) *
+                            (self.upper_bound - self.lower_bound))
 
-    def _global_mapping_fun(self, x, epsilon, lower_bound, upper_bound):
-        probs = list()
-        denominator = np.sum(
-            np.exp(-np.abs(x - np.array(range(lower_bound, upper_bound + 1))) *
-                   epsilon / 2))
-        for k in range(lower_bound, upper_bound + 1):
-            probs.append(np.exp(-np.abs(x - k) * epsilon / 2) / denominator)
-        res = np.random.choice(list(range(lower_bound, upper_bound + 1)),
-                               p=probs)
+        def _global_mapping_fun(self, x, epsilon, lower_bound, upper_bound):
+            probs = list()
+            denominator = np.sum(
+                np.exp(
+                    -np.abs(x - np.array(range(lower_bound, upper_bound + 1)))
+                    * epsilon / 2))
+            for k in range(lower_bound, upper_bound + 1):
+                probs.append(
+                    np.exp(-np.abs(x - k) * epsilon / 2) / denominator)
+            res = np.random.choice(list(range(lower_bound, upper_bound + 1)),
+                                   p=probs)
 
-        return res
+            return res
 
-    def _adjusting_mapping_fun(self, x, partition_edges):
-        for part_idx in range(self.partition_num):
-            if partition_edges[part_idx] < x and partition_edges[part_idx +
-                                                                 1] >= x:
-                selected_part = self._global_mapping_fun(
-                    part_idx,
-                    epsilon=self.epsilon_prt,
-                    lower_bound=0,
-                    upper_bound=self.partition_num - 1)
-                res = self._global_mapping_fun(
-                    x,
-                    epsilon=self.epsilon_ner,
-                    lower_bound=partition_edges[selected_part] + 1,
-                    upper_bound=partition_edges[selected_part + 1])
+        def _adjusting_mapping_fun(self, x, partition_edges):
+            for part_idx in range(self.partition_num):
+                if partition_edges[part_idx] < x and partition_edges[part_idx +
+                                                                     1] >= x:
+                    selected_part = self._global_mapping_fun(
+                        part_idx,
+                        epsilon=self.epsilon_prt,
+                        lower_bound=0,
+                        upper_bound=self.partition_num - 1)
+                    res = self._global_mapping_fun(
+                        x,
+                        epsilon=self.epsilon_ner,
+                        lower_bound=partition_edges[selected_part] + 1,
+                        upper_bound=partition_edges[selected_part + 1])
 
-                return res
+                    return res
 
-    def _op_boost_global(self, data):
+        def _op_boost_global(self, data):
 
-        processed_data = self._processed_data(data=data)
-        mapped_data = np.vectorize(self._global_mapping_fun)(
-            processed_data,
-            epsilon=self.epsilon,
-            lower_bound=self.lower_bound,
-            upper_bound=self.upper_bound)
+            processed_data = self._processed_data(data=data)
+            mapped_data = np.vectorize(self._global_mapping_fun)(
+                processed_data,
+                epsilon=self.epsilon,
+                lower_bound=self.lower_bound,
+                upper_bound=self.upper_bound)
 
-        return mapped_data
+            return mapped_data
 
-    def _op_boost_adjusting(self, data):
+        def _op_boost_adjusting(self, data):
 
-        processed_data = self._processed_data(data=data)
-        quantiles = np.linspace(0, 100, self.partition_num + 1)
-        partition_edges = np.round(
-            np.asarray(
-                np.percentile(
-                    list(range(self.lower_bound - 1, self.upper_bound + 1)),
-                    quantiles)))
-        partition_edges = [int(x) for x in partition_edges]
-        mapped_data = np.vectorize(self._adjusting_mapping_fun,
-                                   signature='(),(n)->()')(
-                                       processed_data,
-                                       partition_edges=partition_edges)
+            processed_data = self._processed_data(data=data)
+            quantiles = np.linspace(0, 100, self.partition_num + 1)
+            partition_edges = np.round(
+                np.asarray(
+                    np.percentile(
+                        list(range(self.lower_bound - 1,
+                                   self.upper_bound + 1)), quantiles)))
+            partition_edges = [int(x) for x in partition_edges]
+            mapped_data = np.vectorize(self._adjusting_mapping_fun,
+                                       signature='(),(n)->()')(
+                                           processed_data,
+                                           partition_edges=partition_edges)
 
-        return mapped_data
+            return mapped_data
 
-    def _protect_via_op_boost(self, raw_feature_order, data):
-        """
-            Add random noises to feature order for privacy protection.
-            For more details, please see
+        def _protect_via_op_boost(self, raw_feature_order, data):
+            """
+                Add random noises to feature order for privacy protection.
+                For more details, please see
                 OpBoost: A Vertical Federated Tree Boosting Framework Based on
                     Order-Preserving Desensitization.pdf
                 (https://arxiv.org/pdf/2210.01318.pdf)
-        """
-        if self.algo == 'global':
-            mapped_data = self._op_boost_global(data)
-        elif self.algo == 'adjusting':
-            mapped_data = self._op_boost_adjusting(data)
-        else:
-            mapped_data = None
-        assert mapped_data is not None
+            """
+            if self.algo == 'global':
+                mapped_data = self._op_boost_global(data)
+            elif self.algo == 'adjusting':
+                mapped_data = self._op_boost_adjusting(data)
+            else:
+                mapped_data = None
+            assert mapped_data is not None
 
-        # Get feature order based on mapped data
-        num_of_feature = mapped_data.shape[1]
-        protected_feature_order = [0] * num_of_feature
-        for i in range(num_of_feature):
-            protected_feature_order[i] = mapped_data[:, i].argsort()
+            # Get feature order based on mapped data
+            num_of_feature = mapped_data.shape[1]
+            protected_feature_order = [0] * num_of_feature
+            for i in range(num_of_feature):
+                protected_feature_order[i] = mapped_data[:, i].argsort()
 
-        return {
-            'raw_feature_order': raw_feature_order,
-            'feature_order': protected_feature_order,
-        }
+            return {
+                'raw_feature_order': raw_feature_order,
+                'feature_order': protected_feature_order,
+            }
 
-    def _protect_via_dp(self, raw_feature_order, data):
-        """
-            Bucketize and add dp noise to feature order for privacy protection.
-            For more details, please refer to
-                FederBoost: Private Federated Learning for GBDT
-                (https://arxiv.org/pdf/2011.02796.pdf)
-        """
-        protected_feature_order = list()
-        bucket_size = int(
-            np.ceil(self.cfg.dataloader.batch_size / self.bucket_num))
-        if self.epsilon is None:
-            prob_for_preserving = 1.0
-        else:
-            _tmp = np.power(np.e, self.epsilon)
-            prob_for_preserving = _tmp / (_tmp + self.bucket_num - 1)
-        prob_for_moving = (1.0 - prob_for_preserving) / (self.bucket_num - 1)
-        split_position = []
-        self.split_value = []
+        def _protect_via_dp(self, raw_feature_order, data):
+            """
+                Bucketize and add dp noise to feature order for protection.
+                For more details, please refer to
+                    FederBoost: Private Federated Learning for GBDT
+                    (https://arxiv.org/pdf/2011.02796.pdf)
+            """
+            protected_feature_order = list()
+            bucket_size = int(
+                np.ceil(self.cfg.dataloader.batch_size / self.bucket_num))
+            if self.epsilon is None:
+                prob_for_preserving = 1.0
+            else:
+                _tmp = np.power(np.e, self.epsilon)
+                prob_for_preserving = _tmp / (_tmp + self.bucket_num - 1)
+            prob_for_moving = (1.0 - prob_for_preserving) / (self.bucket_num -
+                                                             1)
+            split_position = []
+            self.split_value = []
 
-        for feature_idx in range(len(raw_feature_order)):
-            bucketized_feature_order = self._bucketize(
-                raw_feature_order[feature_idx], bucket_size, self.bucket_num)
-            noisy_bucketizd_feature_order = [[]
-                                             for _ in range(self.bucket_num)]
+            for feature_idx in range(len(raw_feature_order)):
+                bucketized_feature_order = self._bucketize(
+                    raw_feature_order[feature_idx], bucket_size,
+                    self.bucket_num)
+                noisy_bucketizd_feature_order = [
+                    [] for _ in range(self.bucket_num)
+                ]
 
-            # Add noise to bucketized feature order
-            for bucket_idx in range(self.bucket_num):
-                probs = np.ones(self.bucket_num) * prob_for_moving
-                probs[bucket_idx] = prob_for_preserving
-                for each in bucketized_feature_order[bucket_idx]:
-                    selected_bucket_idx = np.random.choice(list(
-                        range(self.bucket_num)),
-                                                           p=probs)
-                    noisy_bucketizd_feature_order[selected_bucket_idx].append(
-                        each)
+                # Add noise to bucketized feature order
+                for bucket_idx in range(self.bucket_num):
+                    probs = np.ones(self.bucket_num) * prob_for_moving
+                    probs[bucket_idx] = prob_for_preserving
+                    for each in bucketized_feature_order[bucket_idx]:
+                        selected_bucket_idx = np.random.choice(list(
+                            range(self.bucket_num)),
+                                                               p=probs)
+                        noisy_bucketizd_feature_order[
+                            selected_bucket_idx].append(each)
 
-            # Save split positions (instance number within buckets)
-            # We exclude the endpoints to avoid empty sub-trees
-            _split_position = list()
-            _split_value = dict()
-            accumu_num = 0
-            for bucket_idx, each_bucket in enumerate(
-                    noisy_bucketizd_feature_order):
-                instance_num = len(each_bucket)
-                # Skip the empty bucket
-                if instance_num != 0:
-                    # Skip the endpoints
-                    if bucket_idx != self.bucket_num - 1:
-                        _split_position.append(accumu_num + instance_num)
+                # Save split positions (instance number within buckets)
+                # We exclude the endpoints to avoid empty sub-trees
+                _split_position = list()
+                _split_value = dict()
+                accumu_num = 0
+                for bucket_idx, each_bucket in enumerate(
+                        noisy_bucketizd_feature_order):
+                    instance_num = len(each_bucket)
+                    # Skip the empty bucket
+                    if instance_num != 0:
+                        # Skip the endpoints
+                        if bucket_idx != self.bucket_num - 1:
+                            _split_position.append(accumu_num + instance_num)
 
-                    # Save split values: average of min value of (j-1)-th
-                    # bucket and max value of j-th bucket
-                    max_value = data[bucketized_feature_order[bucket_idx]
-                                     [-1]][feature_idx]
-                    min_value = data[bucketized_feature_order[bucket_idx]
-                                     [0]][feature_idx]
-                    if accumu_num == 0:
-                        _split_value[accumu_num +
-                                     instance_num] = max_value / 2.0
-                    elif bucket_idx == self.bucket_num - 1:
-                        _split_value[accumu_num] += min_value / 2.0
-                    else:
-                        _split_value[accumu_num] += min_value / 2.0
-                        _split_value[accumu_num +
-                                     instance_num] = max_value / 2.0
+                        # Save split values: average of min value of (j-1)-th
+                        # bucket and max value of j-th bucket
+                        max_value = data[bucketized_feature_order[bucket_idx]
+                                         [-1]][feature_idx]
+                        min_value = data[bucketized_feature_order[bucket_idx]
+                                         [0]][feature_idx]
+                        if accumu_num == 0:
+                            _split_value[accumu_num +
+                                         instance_num] = max_value / 2.0
+                        elif bucket_idx == self.bucket_num - 1:
+                            _split_value[accumu_num] += min_value / 2.0
+                        else:
+                            _split_value[accumu_num] += min_value / 2.0
+                            _split_value[accumu_num +
+                                         instance_num] = max_value / 2.0
 
-                    accumu_num += instance_num
+                        accumu_num += instance_num
 
-            split_position.append(_split_position)
-            self.split_value.append(_split_value)
+                split_position.append(_split_position)
+                self.split_value.append(_split_value)
 
-            [np.random.shuffle(x) for x in noisy_bucketizd_feature_order]
-            noisy_bucketizd_feature_order = np.concatenate(
-                noisy_bucketizd_feature_order)
-            protected_feature_order.append(noisy_bucketizd_feature_order)
+                [np.random.shuffle(x) for x in noisy_bucketizd_feature_order]
+                noisy_bucketizd_feature_order = np.concatenate(
+                    noisy_bucketizd_feature_order)
+                protected_feature_order.append(noisy_bucketizd_feature_order)
 
-        extra_info = {'split_position': split_position}
+            extra_info = {'split_position': split_position}
 
-        return {
-            'raw_feature_order': raw_feature_order,
-            'feature_order': protected_feature_order,
-            'extra_info': extra_info
-        }
+            return {
+                'raw_feature_order': raw_feature_order,
+                'feature_order': protected_feature_order,
+                'extra_info': extra_info
+            }
 
-    # TODO: more flexible for client to choose whether to protect or not
-    def _get_feature_order_info(self, data):
-        num_of_feature = data.shape[1]
-        feature_order = [0] * num_of_feature
-        for i in range(num_of_feature):
-            feature_order[i] = data[:, i].argsort()
-        return self.protect_funcs(feature_order, data)
+        # TODO: more flexible for client to choose whether to protect or not
+        def _get_feature_order_info(self, data):
+            num_of_feature = data.shape[1]
+            feature_order = [0] * num_of_feature
+            for i in range(num_of_feature):
+                feature_order[i] = data[:, i].argsort()
+            return self.protect_funcs(feature_order, data)
+
+    return FeatureOrderProtectedTrainer(model, data, device, config, monitor)

--- a/federatedscope/vertical_fl/trainer/random_forest_trainer.py
+++ b/federatedscope/vertical_fl/trainer/random_forest_trainer.py
@@ -49,14 +49,23 @@ class RandomForestTrainer(VerticalTrainer):
         if self.extra_info is not None:
             split_position = self.extra_info.get('split_position', None)
 
+        activate_idx = [
+            np.nonzero(self.model[tree_num][node_num].indicator[order])[0]
+            for order in self.merged_feature_order
+        ]
+        activate_idx = np.asarray(activate_idx)
         if split_position is None:
-            activate_idx = [
-                np.nonzero(self.model[tree_num][node_num].indicator[order])[0]
-                for order in self.merged_feature_order
-            ]
-            activate_idx = np.asarray(activate_idx)
             # The left/right sub-tree cannot be empty
             split_position = activate_idx[:, 1:]
+        else:
+            active_split_position = list()
+            for idx, each_split_position in enumerate(split_position):
+                active_split_position.append([
+                    x for x in each_split_position
+                    if x in activate_idx[idx, 1:]
+                ])
+            split_position = active_split_position
+
         for feature_idx in range(feature_num):
             if len(split_position[feature_idx]) == 0:
                 continue

--- a/federatedscope/vertical_fl/trainer/random_forest_trainer.py
+++ b/federatedscope/vertical_fl/trainer/random_forest_trainer.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+from federatedscope.vertical_fl.trainer import VerticalTrainer
+from federatedscope.vertical_fl.dataloader.utils import VerticalDataSampler
+from federatedscope.vertical_fl.loss.utils import get_vertical_loss
+
+
+class RandomForestTrainer(VerticalTrainer):
+    def __init__(self, model, data, device, config, monitor):
+        super(RandomForestTrainer, self).__init__(model, data, device, config,
+                                                  monitor)
+
+    def _init_for_train(self):
+        self.eta = 1.0
+        self.model.set_task_type(self.cfg.criterion.type)
+        self.dataloader = VerticalDataSampler(
+            data=self.data['train'],
+            replace=True,
+            use_full_trainset=False,
+            feature_frac=self.cfg.vertical.feature_subsample_ratio)
+        self.criterion = get_vertical_loss(loss_type=self.cfg.criterion.type,
+                                           model_type=self.cfg.model.type)
+
+    def _compute_for_root(self, tree_num):
+        node_num = 0
+        self.model[tree_num][node_num].label = self.batch_y
+        self.model[tree_num][node_num].indicator = np.ones(len(self.batch_y))
+        return self._compute_for_node(tree_num, node_num=node_num)
+
+    def _get_ordered_indicator_and_label(self, tree_num, node_num,
+                                         feature_idx):
+        order = self.merged_feature_order[feature_idx]
+        ordered_indicator = self.model[tree_num][node_num].indicator[order]
+        ordered_label = self.model[tree_num][node_num].label[order]
+        return ordered_indicator, ordered_label
+
+    def _get_best_gain(self, tree_num, node_num):
+        if self.cfg.criterion.type == 'CrossEntropyLoss':
+            default_gain = 1
+        elif 'Regression' in self.cfg.criterion.type:
+            default_gain = float('inf')
+        else:
+            raise ValueError
+
+        split_ref = {'feature_idx': None, 'value_idx': None}
+        best_gain = default_gain
+        feature_num = len(self.merged_feature_order)
+        split_position = None
+        if self.extra_info is not None:
+            split_position = self.extra_info.get('split_position', None)
+
+        if split_position is None:
+            activate_idx = [
+                np.nonzero(self.model[tree_num][node_num].indicator[order])[0]
+                for order in self.merged_feature_order
+            ]
+            activate_idx = np.asarray(activate_idx)
+            # The left/right sub-tree cannot be empty
+            split_position = activate_idx[:, 1:]
+        for feature_idx in range(feature_num):
+            if len(split_position[feature_idx]) == 0:
+                continue
+            ordered_indicator, ordered_label = \
+                self._get_ordered_indicator_and_label(
+                    tree_num, node_num, feature_idx)
+            for value_idx in split_position[feature_idx]:
+                gain = self.model[tree_num].cal_gain(value_idx, ordered_label,
+                                                     ordered_indicator)
+                if gain < best_gain:
+                    best_gain = gain
+                    split_ref['feature_idx'] = feature_idx
+                    split_ref['value_idx'] = value_idx
+
+        return best_gain < default_gain, split_ref

--- a/federatedscope/vertical_fl/trainer/trainer.py
+++ b/federatedscope/vertical_fl/trainer/trainer.py
@@ -160,14 +160,23 @@ class VerticalTrainer(object):
         if self.extra_info is not None:
             split_position = self.extra_info.get('split_position', None)
 
+        activate_idx = [
+            np.nonzero(self.model[tree_num][node_num].indicator[order])[0]
+            for order in self.merged_feature_order
+        ]
+        activate_idx = np.asarray(activate_idx)
         if split_position is None:
-            activate_idx = [
-                np.nonzero(self.model[tree_num][node_num].indicator[order])[0]
-                for order in self.merged_feature_order
-            ]
-            activate_idx = np.asarray(activate_idx)
             # The left/right sub-tree cannot be empty
             split_position = activate_idx[:, 1:]
+        else:
+            active_split_position = list()
+            for idx, each_split_position in enumerate(split_position):
+                active_split_position.append([
+                    x for x in each_split_position
+                    if x in activate_idx[idx, 1:]
+                ])
+            split_position = active_split_position
+
         for feature_idx in range(feature_num):
             ordered_g, ordered_h = self._get_ordered_gh(
                 tree_num, node_num, feature_idx)

--- a/federatedscope/vertical_fl/trainer/trainer.py
+++ b/federatedscope/vertical_fl/trainer/trainer.py
@@ -26,8 +26,6 @@ class VerticalTrainer(object):
         self.batch_y_hat = None
         self.batch_z = 0
 
-        self._init_for_train()
-
     def _init_for_train(self):
         self.eta = self.cfg.train.optimizer.eta
         self.dataloader = VerticalDataSampler(

--- a/federatedscope/vertical_fl/trainer/utils.py
+++ b/federatedscope/vertical_fl/trainer/utils.py
@@ -1,10 +1,16 @@
 from federatedscope.vertical_fl.trainer import VerticalTrainer, \
-    FeatureOrderProtectedTrainer
+    FeatureOrderProtectedTrainer, RandomForestTrainer
 
 
 def get_vertical_trainer(config, model, data, device, monitor):
 
     protect_object = config.vertical.protect_object
+    if config.model.type.lower() == 'random_forest':
+        return RandomForestTrainer(model=model,
+                                   data=data,
+                                   device=device,
+                                   config=config,
+                                   monitor=monitor)
     if not protect_object or protect_object == '':
         return VerticalTrainer(model=model,
                                data=data,

--- a/federatedscope/vertical_fl/trainer/utils.py
+++ b/federatedscope/vertical_fl/trainer/utils.py
@@ -1,27 +1,27 @@
 from federatedscope.vertical_fl.trainer import VerticalTrainer, \
-    FeatureOrderProtectedTrainer, RandomForestTrainer
+    RandomForestTrainer, createFeatureOrderProtectedTrainer
 
 
 def get_vertical_trainer(config, model, data, device, monitor):
 
-    protect_object = config.vertical.protect_object
     if config.model.type.lower() == 'random_forest':
-        return RandomForestTrainer(model=model,
-                                   data=data,
-                                   device=device,
-                                   config=config,
-                                   monitor=monitor)
+        trainer_cls = RandomForestTrainer
+    else:
+        trainer_cls = VerticalTrainer
+
+    protect_object = config.vertical.protect_object
     if not protect_object or protect_object == '':
-        return VerticalTrainer(model=model,
-                               data=data,
-                               device=device,
-                               config=config,
-                               monitor=monitor)
+        return trainer_cls(model=model,
+                           data=data,
+                           device=device,
+                           config=config,
+                           monitor=monitor)
     elif protect_object == 'feature_order':
-        return FeatureOrderProtectedTrainer(model=model,
-                                            data=data,
-                                            device=device,
-                                            config=config,
-                                            monitor=monitor)
+        return createFeatureOrderProtectedTrainer(cls=trainer_cls,
+                                                  model=model,
+                                                  data=data,
+                                                  device=device,
+                                                  config=config,
+                                                  monitor=monitor)
     else:
         raise ValueError

--- a/federatedscope/vertical_fl/utils.py
+++ b/federatedscope/vertical_fl/utils.py
@@ -4,7 +4,7 @@ from federatedscope.vertical_fl.xgb_base.worker import wrap_client_for_train, \
 
 
 def wrap_vertical_server(server, config):
-    if config.vertical.algo in ['xgb', 'gbdt']:
+    if config.vertical.algo in ['xgb', 'gbdt', 'rf']:
         server = wrap_server_for_train(server)
         server = wrap_server_for_evaluation(server)
 
@@ -12,7 +12,7 @@ def wrap_vertical_server(server, config):
 
 
 def wrap_vertical_client(client, config):
-    if config.vertical.algo in ['xgb', 'gbdt']:
+    if config.vertical.algo in ['xgb', 'gbdt', 'rf']:
         client = wrap_client_for_train(client)
         client = wrap_client_for_evaluation(client)
 

--- a/federatedscope/vertical_fl/xgb_base/baseline/gbdt_base_on_adult.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/gbdt_base_on_adult.yaml
@@ -29,6 +29,7 @@ vertical:
   use: True
   dims: [7, 14]
   algo: 'gbdt'
+  data_size_for_debug: 2000
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/rf_base_on_adult.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/rf_base_on_adult.yaml
@@ -5,11 +5,11 @@ federate:
   mode: standalone
   client_num: 2
 model:
-  type: xgb_tree
+  type: random_forest
   lambda_: 0.1
   gamma: 0
   num_of_trees: 10
-  max_tree_depth: 3
+  max_tree_depth: 5
 data:
   root: data/
   type: adult
@@ -21,18 +21,12 @@ criterion:
   type: CrossEntropyLoss
 trainer:
   type: verticaltrainer
-train:
-  optimizer:
-    # learning rate for xgb model
-    eta: 0.5
 vertical:
   use: True
   dims: [7, 14]
-  algo: 'xgb'
-  protect_object: 'feature_order'
-  protect_method: 'dp'
-  protect_args: [{'bucket_num': 100, 'epsilon':10}]
-  data_size_for_debug: 2000
+  algo: 'rf'
+  data_size_for_debug: 1500
+  feature_subsample_ratio: 0.8
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_abalone.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_abalone.yaml
@@ -29,6 +29,7 @@ vertical:
   use: True
   dims: [4, 8]
   algo: 'xgb'
+  data_size_for_debug: 2000
 eval:
   freq: 5
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_adult.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_adult.yaml
@@ -29,6 +29,7 @@ vertical:
   use: True
   dims: [7, 14]
   algo: 'xgb'
+  data_size_for_debug: 2000
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_blogfeedback.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_blogfeedback.yaml
@@ -29,6 +29,7 @@ vertical:
   use: True
   dims: [10, 20]
   algo: 'xgb'
+  data_size_for_debug: 2000
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_givemesomecredit.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/xgb_base_on_givemesomecredit.yaml
@@ -29,6 +29,7 @@ vertical:
   use: True
   dims: [5, 10]
   algo: 'xgb'
+  data_size_for_debug: 2000
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/baseline/xgb_feature_order_op_boost_on_adult.yaml
+++ b/federatedscope/vertical_fl/xgb_base/baseline/xgb_feature_order_op_boost_on_adult.yaml
@@ -32,6 +32,7 @@ vertical:
   protect_object: 'feature_order'
   protect_method: 'op_boost'
   protect_args: [{'algo': 'global'}]
+  data_size_for_debug: 2000
 eval:
   freq: 3
   best_res_update_round_wise_key: test_loss

--- a/federatedscope/vertical_fl/xgb_base/worker/XGBClient.py
+++ b/federatedscope/vertical_fl/xgb_base/worker/XGBClient.py
@@ -61,6 +61,7 @@ class XGBClient(Client):
 
     def _init_data_related_var(self):
 
+        self.trainer._init_for_train()
         self.test_x = None
         self.test_y = None
 

--- a/federatedscope/vertical_fl/xgb_base/worker/evaluation_wrapper.py
+++ b/federatedscope/vertical_fl/xgb_base/worker/evaluation_wrapper.py
@@ -10,12 +10,12 @@ logger = logging.getLogger(__name__)
 
 def wrap_client_for_evaluation(client):
     def eval(self, tree_num):
-        self.criterion = get_vertical_loss(
-            self._cfg.criterion.type,
-            cal_hess=(self._cfg.model.type == 'xgb_tree'))
+        self.criterion = get_vertical_loss(loss_type=self._cfg.criterion.type,
+                                           model_type=self._cfg.model.type)
         if self.test_x is None:
             self.test_x, self.test_y = self._fetch_test_data()
-            self.test_result = np.zeros(self.test_x.shape[0])
+            self.merged_test_result = list()
+        self.test_result = np.zeros(self.test_x.shape[0])
         self.model[tree_num][0].indicator = np.ones(self.test_x.shape[0])
         self._test_for_node(tree_num, node_num=0)
 
@@ -26,8 +26,10 @@ def wrap_client_for_evaluation(client):
         return test_x, test_y
 
     def _feedback_eval_metrics(self):
-        test_loss = self.criterion.get_loss(self.test_y, self.test_result)
-        metrics = self.criterion.get_metric(self.test_y, self.test_result)
+        test_loss = self.criterion.get_loss(self.test_y,
+                                            self.merged_test_result)
+        metrics = self.criterion.get_metric(self.test_y,
+                                            self.merged_test_result)
         modified_metrics = dict()
         for key in metrics.keys():
             if 'test' not in key:
@@ -65,6 +67,7 @@ def wrap_client_for_evaluation(client):
     def _test_for_node(self, tree_num, node_num):
         # All nodes have been traversed
         if node_num >= 2**self.model.max_depth - 1:
+            self.merged_test_result.append(self.test_result)
             if (
                     tree_num + 1
             ) % self._cfg.eval.freq == 0 or \
@@ -74,9 +77,13 @@ def wrap_client_for_evaluation(client):
             self._check_eval_finish(tree_num)
         # The client owns the weight
         elif self.model[tree_num][node_num].weight:
+            if self._cfg.model.type in ['xgb_tree', 'gbdt_tree']:
+                eta = self._cfg.train.optimizer.eta
+            else:
+                eta = 1.0
             self.test_result += self.model[tree_num][
                 node_num].indicator * self.model[tree_num][
-                    node_num].weight * self._cfg.train.optimizer.eta
+                    node_num].weight * eta
             self._test_for_node(tree_num, node_num + 1)
         # Other client owns the weight, need to communicate
         elif self.model[tree_num][node_num].member:
@@ -92,7 +99,6 @@ def wrap_client_for_evaluation(client):
     def callback_func_for_split_request(self, message: Message):
         if self.test_x is None:
             self.test_x, self.test_y = self._fetch_test_data()
-            self.test_result = np.zeros(self.test_x.shape[0])
         tree_num, node_num = message.content
         sender = message.sender
         feature_idx = self.model[tree_num][node_num].feature_idx

--- a/federatedscope/vertical_fl/xgb_base/worker/train_wrapper.py
+++ b/federatedscope/vertical_fl/xgb_base/worker/train_wrapper.py
@@ -11,7 +11,6 @@ def wrap_client_for_train(client):
         if node_num is None:
             logger.info(f'----------- Building a new tree (Tree '
                         f'#{tree_num}) -------------')
-            self.state = tree_num
             finish_flag, results = self.trainer.train(
                 feature_order_info=feature_order_info, tree_num=tree_num)
         else:
@@ -31,17 +30,18 @@ def wrap_client_for_train(client):
     def _check_eval_finish(self, tree_num):
         if self.eval_finish_flag:
             if tree_num + 1 < self._cfg.model.num_of_trees:
-                self.train(tree_num + 1)
+                batch_index, feature_order_info = \
+                    self.trainer.fetch_train_data()
+                self.start_a_new_training_round(batch_index,
+                                                feature_order_info,
+                                                tree_num=tree_num + 1)
 
     def _find_and_send_split(self, split_ref, tree_num, node_num):
-        for index, dim in enumerate(self._cfg.vertical.dims):
-            if split_ref['feature_idx'] < dim:
-                prefix = self._cfg.vertical.dims[index -
-                                                 1] if index != 0 else 0
+        accum_dim = 0
+        for index, dim in enumerate(self.trainer.client_feature_num):
+            if split_ref['feature_idx'] < accum_dim + dim:
                 client_id = index + 1
                 self.model[tree_num][node_num].member = client_id
-                self.model[tree_num][
-                    node_num].feature_idx = split_ref['feature_idx'] - prefix
 
                 self.comm_manager.send(
                     Message(msg_type='split',
@@ -49,19 +49,22 @@ def wrap_client_for_train(client):
                             state=self.state,
                             receiver=[client_id],
                             content=(tree_num, node_num,
-                                     split_ref['feature_idx'] - prefix,
+                                     split_ref['feature_idx'] - accum_dim,
                                      split_ref['value_idx'])))
                 break
+            else:
+                accum_dim += dim
 
     def callback_func_for_split(self, message: Message):
         tree_num, node_num, feature_idx, value_idx = message.content
         sender = message.sender
         self.state = message.state
-        self.feature_importance[feature_idx] += 1
+        abs_feature_idx = self.trainer.get_abs_feature_idx(feature_idx)
+        self.feature_importance[abs_feature_idx] += 1
 
         feature_value = self.trainer.get_feature_value(feature_idx, value_idx)
 
-        self.model[tree_num][node_num].feature_idx = feature_idx
+        self.model[tree_num][node_num].feature_idx = abs_feature_idx
         self.model[tree_num][node_num].feature_value = feature_value
 
         self.comm_manager.send(

--- a/tests/test_tree_based_model_for_vfl.py
+++ b/tests/test_tree_based_model_for_vfl.py
@@ -25,14 +25,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -42,6 +41,7 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.use = True
         cfg.vertical.dims = [7, 14]
         cfg.vertical.algo = 'xgb'
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -61,14 +61,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'gbdt_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -78,6 +77,42 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.use = True
         cfg.vertical.dims = [7, 14]
         cfg.vertical.algo = 'gbdt'
+        cfg.vertical.data_size_for_debug = 2000
+
+        cfg.trainer.type = 'verticaltrainer'
+        cfg.eval.freq = 5
+        cfg.eval.best_res_update_round_wise_key = "test_loss"
+
+        return backup_cfg
+
+    def set_config_for_rf_base(self, cfg):
+        backup_cfg = cfg.clone()
+
+        import torch
+        cfg.use_gpu = torch.cuda.is_available()
+
+        cfg.federate.mode = 'standalone'
+        cfg.federate.client_num = 2
+
+        cfg.model.type = 'random_forest'
+        cfg.model.lambda_ = 0.1
+        cfg.model.gamma = 0
+        cfg.model.num_of_trees = 10
+        cfg.model.max_tree_depth = 5
+
+        cfg.data.root = 'test_data/'
+        cfg.data.type = 'adult'
+
+        cfg.dataloader.type = 'raw'
+        cfg.dataloader.batch_size = 1500
+
+        cfg.criterion.type = 'CrossEntropyLoss'
+
+        cfg.vertical.use = True
+        cfg.vertical.dims = [7, 14]
+        cfg.vertical.algo = 'rf'
+        cfg.vertical.data_size_for_debug = 2000
+        cfg.vertical.feature_subsample_ratio = 0.5
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -97,14 +132,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -117,6 +151,7 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.protect_object = 'feature_order'
         cfg.vertical.protect_method = 'dp'
         cfg.vertical.protect_args = [{'bucket_num': 100, 'epsilon': 10}]
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -136,14 +171,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -155,7 +189,8 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.algo = 'xgb'
         cfg.vertical.protect_object = 'feature_order'
         cfg.vertical.protect_method = 'dp'
-        cfg.vertical.protect_args = [{'bucket_num': 100, 'epsilon': 1}]
+        cfg.vertical.protect_args = [{'bucket_num': 100, 'epsilon': 0.1}]
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -175,14 +210,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -195,6 +229,7 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.protect_object = 'feature_order'
         cfg.vertical.protect_method = 'dp'
         cfg.vertical.protect_args = [{'bucket_num': 100}]
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -214,14 +249,13 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 5
+        cfg.model.num_of_trees = 10
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -234,6 +268,7 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.protect_object = 'feature_order'
         cfg.vertical.protect_method = 'op_boost'
         cfg.vertical.protect_args = [{'algo': 'global'}]
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -241,7 +276,7 @@ class XGBTest(unittest.TestCase):
 
         return backup_cfg
 
-    def set_config_for_xgb_op_boost_local(self, cfg):
+    def set_config_for_xgb_op_boost_adjust(self, cfg):
         backup_cfg = cfg.clone()
 
         import torch
@@ -260,7 +295,6 @@ class XGBTest(unittest.TestCase):
 
         cfg.data.root = 'test_data/'
         cfg.data.type = 'adult'
-        cfg.data.size = 2000
 
         cfg.dataloader.type = 'raw'
         cfg.dataloader.batch_size = 2000
@@ -273,6 +307,7 @@ class XGBTest(unittest.TestCase):
         cfg.vertical.protect_object = 'feature_order'
         cfg.vertical.protect_method = 'op_boost'
         cfg.vertical.protect_args = [{'algo': 'adjusting'}]
+        cfg.vertical.data_size_for_debug = 2000
 
         cfg.trainer.type = 'verticaltrainer'
         cfg.eval.freq = 5
@@ -320,7 +355,28 @@ class XGBTest(unittest.TestCase):
         init_cfg.merge_from_other_cfg(backup_cfg)
         print(test_results)
         self.assertGreater(test_results['server_global_eval']['test_acc'],
-                           0.75)
+                           0.78)
+
+    def test_RF_Base(self):
+        init_cfg = global_cfg.clone()
+        backup_cfg = self.set_config_for_rf_base(init_cfg)
+        setup_seed(init_cfg.seed)
+        update_logger(init_cfg, True)
+
+        data, modified_config = get_data(init_cfg.clone())
+        init_cfg.merge_from_other_cfg(modified_config)
+        self.assertIsNotNone(data)
+
+        Fed_runner = get_runner(data=data,
+                                server_class=get_server_cls(init_cfg),
+                                client_class=get_client_cls(init_cfg),
+                                config=init_cfg.clone())
+        self.assertIsNotNone(Fed_runner)
+        test_results = Fed_runner.run()
+        init_cfg.merge_from_other_cfg(backup_cfg)
+        print(test_results)
+        self.assertGreater(test_results['server_global_eval']['test_acc'],
+                           0.79)
 
     def test_XGB_use_dp(self):
         init_cfg = global_cfg.clone()
@@ -361,7 +417,7 @@ class XGBTest(unittest.TestCase):
         test_results = Fed_runner.run()
         init_cfg.merge_from_other_cfg(backup_cfg)
         print(test_results)
-        self.assertLess(test_results['server_global_eval']['test_acc'], 0.6)
+        self.assertLess(test_results['server_global_eval']['test_acc'], 0.75)
 
     def test_XGB_use_bucket(self):
         init_cfg = global_cfg.clone()
@@ -402,11 +458,12 @@ class XGBTest(unittest.TestCase):
         test_results = Fed_runner.run()
         init_cfg.merge_from_other_cfg(backup_cfg)
         print(test_results)
-        self.assertGreater(test_results['server_global_eval']['test_acc'], 0.7)
+        self.assertGreater(test_results['server_global_eval']['test_acc'],
+                           0.79)
 
-    def test_XGB_use_op_boost_local(self):
+    def test_XGB_use_op_boost_adjust(self):
         init_cfg = global_cfg.clone()
-        backup_cfg = self.set_config_for_xgb_op_boost_local(init_cfg)
+        backup_cfg = self.set_config_for_xgb_op_boost_adjust(init_cfg)
         setup_seed(init_cfg.seed)
         update_logger(init_cfg, True)
 
@@ -422,7 +479,8 @@ class XGBTest(unittest.TestCase):
         test_results = Fed_runner.run()
         init_cfg.merge_from_other_cfg(backup_cfg)
         print(test_results)
-        self.assertGreater(test_results['server_global_eval']['test_acc'], 0.7)
+        self.assertGreater(test_results['server_global_eval']['test_acc'],
+                           0.79)
 
 
 if __name__ == '__main__':

--- a/tests/test_tree_based_model_for_vfl.py
+++ b/tests/test_tree_based_model_for_vfl.py
@@ -171,7 +171,7 @@ class XGBTest(unittest.TestCase):
         cfg.model.type = 'xgb_tree'
         cfg.model.lambda_ = 0.1
         cfg.model.gamma = 0
-        cfg.model.num_of_trees = 10
+        cfg.model.num_of_trees = 5
         cfg.model.max_tree_depth = 3
 
         cfg.train.optimizer.eta = 0.5
@@ -417,7 +417,7 @@ class XGBTest(unittest.TestCase):
         test_results = Fed_runner.run()
         init_cfg.merge_from_other_cfg(backup_cfg)
         print(test_results)
-        self.assertLess(test_results['server_global_eval']['test_acc'], 0.75)
+        self.assertLess(test_results['server_global_eval']['test_acc'], 0.76)
 
     def test_XGB_use_bucket(self):
         init_cfg = global_cfg.clone()


### PR DESCRIPTION
This pr is adapted from #501 , and many thanks for contributions from @qbc2016 !


 The modifications in this pr includes:
- Random forest for vfl
    - A new trainer: random_forest_trainer
    - A new model: random forest (multiple decisions)
    - VerticalDataSampler: to support sampling a batch of data and a subset of features for training
    - Feature protection methods for random forest
 - `vertical.data_size_for_debug`: only use a subset for running vfl when debugging
 - Modify the losses in vfl: to support both `mean` and `sum` operations when calculating loss/acc


How to apply random forest: 
- set `vertical.algo='rf'` and `model.type = 'random_forest'` @rayrayraykk 

Todo: 
- Docs