### PR TITLE
🚀🚀🚀 gRPC enhancement

### DIFF
--- a/federatedscope/core/auxiliaries/utils.py
+++ b/federatedscope/core/auxiliaries/utils.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+import base64
 import random
 import signal
 import pickle
@@ -92,12 +93,15 @@ def merge_dict_of_results(dict1, dict2):
 
 
 def param2tensor(param):
+    # TODO: make it work in `message`
     if isinstance(param, list):
         param = torch.FloatTensor(param)
     elif isinstance(param, int):
         param = torch.tensor(param, dtype=torch.long)
     elif isinstance(param, float):
         param = torch.tensor(param, dtype=torch.float)
+    elif isinstance(param, str):
+        param = pickle.loads((base64.b64decode(param)))
     return param
 
 

--- a/federatedscope/core/monitors/monitor.py
+++ b/federatedscope/core/monitors/monitor.py
@@ -539,7 +539,8 @@ class Monitor(object):
             'Round': rnd,
             'Results_model_metric': model_metric_dict
         }
-        logger.info(formatted_log)
+        if len(model_metric_dict.keys()):
+            logger.info(formatted_log)
 
         return model_metric_dict
 

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -213,6 +213,8 @@ class GeneralTFTrainer(Trainer):
         setattr(ctx, 'eval_metrics', results)
 
     def update(self, model_parameters, strict=False):
+        # TODO: Fixed TF in Distributed mode
+        # 1) `pickle.loads((base64.b64decode(enc_tensor)))` to restore
         self.ctx.model.load_state_dict(model_parameters, strict=strict)
 
     def save_model(self, path, cur_round=-1):

--- a/federatedscope/core/trainers/tf_trainer.py
+++ b/federatedscope/core/trainers/tf_trainer.py
@@ -213,7 +213,7 @@ class GeneralTFTrainer(Trainer):
         setattr(ctx, 'eval_metrics', results)
 
     def update(self, model_parameters, strict=False):
-        # TODO: Fixed TF in Distributed mode
+        # TODO: Fix TF in Distributed mode
         # 1) `pickle.loads((base64.b64decode(enc_tensor)))` to restore
         self.ctx.model.load_state_dict(model_parameters, strict=strict)
 


### PR DESCRIPTION
## Goal

Faster conversion and sending of `model_para`.

## What's New?

* (Raw) Tensor -> List -> `[gRPC_comm_manager_pb2.mSingle().float_value for x in List]`
* (Now) Tensor -> pickle.dumps -> base64.b64encode-> `gRPC_comm_manager_pb2.mSingle().str_value`

## Exp Results on FEMNIST - One communication round

**Message Size (bytes) (🚀 Reduce ~10 x🚀 )**

| Method /Content | ConvNet2 (461822) | ConvNet5(778174) | VGG11(9249470) |
| --------------- | ----------------- | ---------------- | -------------- |
| Baseline        | 15605112          | 36783248         | 558528520      |
| New             | 2477104           | 4182584          | 49404976       |



**Conversion Time (sec)  (🚀 Reduce ~1000 x🚀 )**

| Method /Content | ConvNet2 (461822) | ConvNet5(778174) | VGG11(9249470) |
| --------------- | ----------------- | ---------------- | -------------- |
| Baseline        | 4.328             | 12.137           | 169.711        |
| New             | 0.007             | 0.014            | 0.184          |



**Sending Time (sec)  (🚀 Reduce ~50 x🚀 )**

| Method /Content | ConvNet2 (461822) | ConvNet5(778174) | VGG11(9249470) |
| --------------- | ----------------- | ---------------- | -------------- |
| Baseline        | 0.880             | 2.220            | 25.920         |
| New             | 0.054             | 0.060            | 0.372          |

## TODO

Maybe add support to `bytes` type in `gRPC_comm_manager_pb2` can make it more efficient. 

This feature only enable when `msg_type=='model_type'`, because the bytes are sent via `str_value` in `gRPC_comm_manager_pb2`. It is difficult to distinguish between real strings and Tensor at the receiver side, we can consider modifying `gRPC_comm_manager_pb2` and finish all the type conversion in `Message` to achieve the final goal.