### PR TITLE
Optimize Standalone memory usage in offsite-tuning

### DIFF
--- a/federatedscope/core/workers/server.py
+++ b/federatedscope/core/workers/server.py
@@ -403,7 +403,8 @@ class Server(BaseServer):
             self.state = self.total_round_num + 1
 
         if self.state != self.total_round_num and \
-                self.state % self._cfg.federate.save_freq == 0:
+                self.state % self._cfg.federate.save_freq == 0 and \
+                self._cfg.federate.save_freq > 0:
             path = f'{self.state}_' + self._cfg.federate.save_to
             self.aggregator.save_model(path, self.state)
 

--- a/federatedscope/llm/trainer/trainer.py
+++ b/federatedscope/llm/trainer/trainer.py
@@ -20,8 +20,6 @@ class LLMTrainer(GeneralTorchTrainer):
 
         logits = outputs.logits
         loss = outputs.loss
-        print(logits, loss)
-        print(input_ids, labels, attention_mask)
 
         if torch.isnan(loss):
             ctx.skip_this_batch = CtxVar(True, LIFECYCLE.BATCH)

--- a/federatedscope/llm/trainer/trainer.py
+++ b/federatedscope/llm/trainer/trainer.py
@@ -20,6 +20,8 @@ class LLMTrainer(GeneralTorchTrainer):
 
         logits = outputs.logits
         loss = outputs.loss
+        print(logits, loss)
+        print(input_ids, labels, attention_mask)
 
         if torch.isnan(loss):
             ctx.skip_this_batch = CtxVar(True, LIFECYCLE.BATCH)


### PR DESCRIPTION
When setting `federate.share_local_model` to True in offsite-tuning, we could save a lot of memory!